### PR TITLE
Rename `ColumnDef`s

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
@@ -6,7 +6,7 @@ import java.util.Objects
 import scala.reflect.ClassTag
 
 object ColumnDef {
-  def apply[T](name: String)(implicit ct: ClassTag[T]): TypedColumnDef[T] = new TypedColumnDef[T](name)(ct)
+  def apply[T](name: String)(implicit ct: ClassTag[T]): ColumnDef[T] = new ColumnDef[T](name)(ct)
 }
 
 /**
@@ -15,7 +15,7 @@ object ColumnDef {
   *
   * @see [[de.up.hpi.informationsystems.adbms.definition.ColumnRelation]]
   */
-sealed trait ColumnDef {
+sealed trait UntypedColumnDef {
   /**
     * Holds the type of the contained values.
     */
@@ -37,7 +37,7 @@ sealed trait ColumnDef {
     * Returns an untyped version of this column definition
     * @return untyped version of this column definition
     */
-  def untyped: ColumnDef
+  def untyped: UntypedColumnDef
 
   /**
     * Creates the corresponding [[de.up.hpi.informationsystems.adbms.definition.ColumnStore]]
@@ -47,20 +47,20 @@ sealed trait ColumnDef {
   protected[definition] def buildColumnStore(): ColumnStore
 }
 
-final class TypedColumnDef[T](pName: String)(implicit ct: ClassTag[T]) extends ColumnDef {
+final class ColumnDef[T](pName: String)(implicit ct: ClassTag[T]) extends UntypedColumnDef {
   override type value = T
 
   override val name: String = pName
 
   override val tpe: ClassTag[T] = ct
 
-  override def untyped: ColumnDef = this.asInstanceOf[ColumnDef]
+  override def untyped: UntypedColumnDef = this.asInstanceOf[UntypedColumnDef]
 
   override protected[definition] def buildColumnStore(): TypedColumnStore[T] = ColumnStore[T](this)
 
   // overrides of [[java.lang.Object]]
 
-  override def toString: String = s"""TypedColumnDef[$tpe](name="$name")"""
+  override def toString: String = s"""${this.getClass.getSimpleName}[$tpe](name="$name")"""
 
   override def hashCode(): Int = Objects.hash(name, ct)
 
@@ -69,12 +69,12 @@ final class TypedColumnDef[T](pName: String)(implicit ct: ClassTag[T]) extends C
       false
     else {
       // cast other object
-      val otherTypedColumnDef: TypedColumnDef[T] = o.asInstanceOf[TypedColumnDef[T]]
+      val otherTypedColumnDef: ColumnDef[T] = o.asInstanceOf[ColumnDef[T]]
       if (this.name.equals(otherTypedColumnDef.name) && this.tpe.equals(otherTypedColumnDef.tpe))
         true
       else
         false
     }
 
-  override def clone(): AnyRef = new TypedColumnDef[T](this.name)(this.tpe)
+  override def clone(): AnyRef = new ColumnDef[T](this.name)(this.tpe)
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnStore.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnStore.scala
@@ -4,7 +4,7 @@ package definition
 import scala.collection.mutable
 
 private[definition] object ColumnStore {
-  def apply[T](columnDef: TypedColumnDef[T]): TypedColumnStore[T] = new TypedColumnStore[T](columnDef)
+  def apply[T](columnDef: ColumnDef[T]): TypedColumnStore[T] = new TypedColumnStore[T](columnDef)
 }
 
 /**
@@ -21,7 +21,7 @@ private[definition] sealed trait ColumnStore {
     * Returns the column definition of this Column
     * @return column definition
     */
-  def columnDef: ColumnDef
+  def columnDef: UntypedColumnDef
 
   /**
     * Appends a new value at the end of the Column's store.
@@ -68,9 +68,9 @@ private[definition] sealed trait ColumnStore {
   * @param columnDefInt typed column definition
   * @tparam T type of the values hold by this column
   */
-private[definition] class TypedColumnStore[T](columnDefInt: TypedColumnDef[T]) extends ColumnStore {
+private[definition] class TypedColumnStore[T](columnDefInt: ColumnDef[T]) extends ColumnStore {
   override type valueType = T
-  override def columnDef: ColumnDef = columnDefInt
+  override def columnDef: UntypedColumnDef = columnDefInt
   private val data: mutable.Buffer[T] = mutable.Buffer.empty
 
   override def append(value: T): Unit = data.append(value)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -4,9 +4,9 @@ import java.util.Objects
 
 import scala.collection.{MapLike, mutable}
 
-class Record private (cells: Map[ColumnDef, Any])
-  extends MapLike[ColumnDef, Any, Record]
-    with Map[ColumnDef, Any] {
+class Record private (cells: Map[UntypedColumnDef, Any])
+  extends MapLike[UntypedColumnDef, Any, Record]
+    with Map[UntypedColumnDef, Any] {
 
   private val data = cells
 
@@ -14,7 +14,7 @@ class Record private (cells: Map[ColumnDef, Any])
     * Returns column definitions in this record.
     * Alias to `keys`
     */
-  val columns: Seq[ColumnDef] = cells.keys.toSeq
+  val columns: Seq[UntypedColumnDef] = cells.keys.toSeq
 
   /**
     * Optionally returns the cell's value of a specified column.
@@ -23,7 +23,7 @@ class Record private (cells: Map[ColumnDef, Any])
     * @tparam T type of the cell's value
     * @return the value of the column's cell wrapped in an `Option`
     */
-  def get[T](columnDef: TypedColumnDef[T]): Option[T] =
+  def get[T](columnDef: ColumnDef[T]): Option[T] =
     if(data.contains(columnDef))
       Some(data(columnDef).asInstanceOf[T])
     else
@@ -33,23 +33,23 @@ class Record private (cells: Map[ColumnDef, Any])
   // from MapLike
   override def empty: Record = new Record(Map.empty)
 
-  override def default(key: ColumnDef): Any = null
+  override def default(key: UntypedColumnDef): Any = null
 
   /**
     * Use [[de.up.hpi.informationsystems.adbms.definition.Record#get]] instead!
     * It takes care of types!
     */
   @Deprecated
-  override def get(key: ColumnDef): Option[Any] = get(key.asInstanceOf[TypedColumnDef[Any]])
+  override def get(key: UntypedColumnDef): Option[Any] = get(key.asInstanceOf[ColumnDef[Any]])
 
-  override def iterator: Iterator[(ColumnDef, Any)] = data.iterator
+  override def iterator: Iterator[(UntypedColumnDef, Any)] = data.iterator
 
-  override def +[V1 >: Any](kv: (ColumnDef, V1)): Map[ColumnDef, V1] = data.+(kv)
+  override def +[V1 >: Any](kv: (UntypedColumnDef, V1)): Map[UntypedColumnDef, V1] = data.+(kv)
 
-  override def -(key: ColumnDef): Record = new Record(data - key)
+  override def -(key: UntypedColumnDef): Record = new Record(data - key)
 
   // from Iterable
-  override def seq: Map[ColumnDef, Any] = data.seq
+  override def seq: Map[UntypedColumnDef, Any] = data.seq
 
   // from Object
   override def toString: String = s"Record($data)"
@@ -70,7 +70,7 @@ class Record private (cells: Map[ColumnDef, Any])
 
   // FIXME: I don't know what to do here.
   // removing this line leads to a compiler error
-  override protected[this] def newBuilder: mutable.Builder[(ColumnDef, Any), Record] = ???
+  override protected[this] def newBuilder: mutable.Builder[(UntypedColumnDef, Any), Record] = ???
 }
 
 object Record {
@@ -104,13 +104,13 @@ object Record {
     * This call initiates the [[de.up.hpi.informationsystems.adbms.definition.Record.RecordBuilder]] with
     * the column definitions of the corresponding relational schema
     */
-  def apply(columnDefs: Seq[ColumnDef]): RecordBuilder = new RecordBuilder(columnDefs, Map.empty)
+  def apply(columnDefs: Seq[UntypedColumnDef]): RecordBuilder = new RecordBuilder(columnDefs, Map.empty)
 
   /**
     * Builder for a [[de.up.hpi.informationsystems.adbms.definition.Record]]
     * @param columnDefs all columns of the corresponding relational schema
     */
-  class RecordBuilder(columnDefs: Seq[ColumnDef], recordData: Map[ColumnDef, Any]) {
+  class RecordBuilder(columnDefs: Seq[UntypedColumnDef], recordData: Map[UntypedColumnDef, Any]) {
 
     /**
       *
@@ -118,13 +118,13 @@ object Record {
       * @tparam T value type, same as for the column definition
       * @return the [[RecordBuilder]] itself for
       */
-    def apply[T](in: (TypedColumnDef[T], T)): RecordBuilder =
+    def apply[T](in: (ColumnDef[T], T)): RecordBuilder =
       new RecordBuilder(columnDefs, recordData ++ Map(in))
 
-    def withCellContent[T](in: (TypedColumnDef[T], T)): RecordBuilder = apply(in)
+    def withCellContent[T](in: (ColumnDef[T], T)): RecordBuilder = apply(in)
 
     def build(): Record = {
-      val data: Map[ColumnDef, Any] = columnDefs
+      val data: Map[UntypedColumnDef, Any] = columnDefs
         .map{ colDef => Map(colDef -> recordData.getOrElse(colDef, null)) }
         .reduce( _ ++ _)
       new Record(data)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -8,7 +8,7 @@ trait Relation {
     * Returns the column definitions of this relation.
     * @return a sequence of column definitions
     */
-  def columns: Seq[ColumnDef]
+  def columns: Seq[UntypedColumnDef]
 
   /**
     * Inserts a [[de.up.hpi.informationsystems.adbms.definition.Record]] into the relation
@@ -22,7 +22,7 @@ trait Relation {
     * @tparam T value type of the column
     * @return all records for which the function is true
     */
-  def where[T](f: (TypedColumnDef[T], T => Boolean)): Seq[Record]
+  def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record]
 
   /**
     * Returns all records satisfying all provided conditions.
@@ -30,7 +30,7 @@ trait Relation {
     * @param fs map of column definitions and functions on the respective column
     * @return all records for which all functions are true
     */
-  def whereAll(fs: Map[ColumnDef, Any => Boolean]): Seq[Record]
+  def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Seq[Record]
 
 
   // this trait comes with this for nothing :)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -14,10 +14,10 @@ object RowRelation {
     * @param columnDefs sequence of column definitions
     * @return the generated row-oriented relational store
     */
-  def apply(columnDefs: Seq[ColumnDef]): RowRelation = new RowRelationStore(columnDefs)
+  def apply(columnDefs: Seq[UntypedColumnDef]): RowRelation = new RowRelationStore(columnDefs)
 
   /**
-    * Indicates that a [[de.up.hpi.informationsystems.adbms.definition.ColumnDef]] was not found in
+    * Indicates that a [[de.up.hpi.informationsystems.adbms.definition.UntypedColumnDef]] was not found in
     * the row relation.
     *
     * @param message gives details
@@ -37,33 +37,33 @@ object RowRelation {
     * Private (hidden) implementation of the [[de.up.hpi.informationsystems.adbms.definition.RowRelation]] trait.
     * @param colDefs column definitions used to construct the underlying data store
     */
-  private final class RowRelationStore(private val colDefs: Seq[ColumnDef]) extends RowRelation {
+  private final class RowRelationStore(private val colDefs: Seq[UntypedColumnDef]) extends RowRelation {
 
     private var data: Seq[Record] = Seq.empty
 
     /** @inheritdoc */
-    override def columns: Seq[ColumnDef] = colDefs
+    override def columns: Seq[UntypedColumnDef] = colDefs
 
     /** @inheritdoc */
     override def insert(record: Record): Unit = data = data :+ record
 
     /** @inheritdoc */
-    override def where[T](f: (TypedColumnDef[T], T => Boolean)): Seq[Record] =
+    override def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record] =
       data.filter{ record => record.get[T](f._1).exists(f._2) }
 
     /** @inheritdoc */
-    override def whereAll(fs: Map[ColumnDef, Any => Boolean]): Seq[Record] =
+    override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Seq[Record] =
       // filter all records
       data.filter{ record =>
         fs.keys
           // map over all supplied filters (key = column)
-          .map { col: ColumnDef =>
+          .map { col: UntypedColumnDef =>
             /* `val rVal = record(col)` returns the value in the record for the column `col`
              * `val filterF = fs(col)` returns the filter for column `col`
              * `val res = filterF(rVal)` applies the filter to the value of the record and corresponding column,
              * returning `true` or `false`
              */
-          fs(col)(record(col))
+            fs(col)(record(col))
           }
           // test if all filters for this record are true
           .forall(_ == true)

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -14,9 +14,9 @@ object TestApplication extends App {
     * Definition of Columns and Relations for relation "User"
     */
   object UserRelationDefinition {
-    val colFirstname: TypedColumnDef[String] = ColumnDef("Firstname")
-    val colLastname: TypedColumnDef[String] = ColumnDef("Lastname")
-    val colAge: TypedColumnDef[Int] = ColumnDef("Age")
+    val colFirstname: ColumnDef[String] = ColumnDef("Firstname")
+    val colLastname: ColumnDef[String] = ColumnDef("Lastname")
+    val colAge: ColumnDef[Int] = ColumnDef("Age")
 
     val R: ColumnRelation = ColumnRelation(Seq(colFirstname, colLastname, colAge))
   }
@@ -25,9 +25,9 @@ object TestApplication extends App {
     * Definition of Columns and Relations for relation "Customer"
     */
   object CustomerRelationDefinition {
-    val colCustomerId: TypedColumnDef[Int] = ColumnDef("Id")
-    val colCustomerName: TypedColumnDef[String] = ColumnDef("Name")
-    val colCustomerDiscount: TypedColumnDef[Double] = ColumnDef("Discount")
+    val colCustomerId: ColumnDef[Int] = ColumnDef("Id")
+    val colCustomerName: ColumnDef[String] = ColumnDef("Name")
+    val colCustomerDiscount: ColumnDef[Double] = ColumnDef("Discount")
 
     val R: RowRelation = RowRelation(Seq(colCustomerId, colCustomerName, colCustomerDiscount))
   }
@@ -77,7 +77,7 @@ object TestApplication extends App {
   )
 
   assert(ColumnDef[String]("Firstname") == colFirstname)
-  assert(ColumnDef[Int]("Firstname").asInstanceOf[ColumnDef] != colFirstname.asInstanceOf[ColumnDef])
+  assert(ColumnDef[Int]("Firstname").untyped != colFirstname.untyped)
 
 
   /**


### PR DESCRIPTION
## Proposed Changes

  - Refactor column definition API
  - `ColumnDef` --> `UntypedColumnDef`
  - `TypedColumnDef[T]` --> `ColumnDef[T]`
  - typed version should be preferred, so we make it more appealing

## Related

  - based on #8 
