### PR TITLE
Fix #11 return None instead of Some(null) from Record.get

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -25,7 +25,7 @@ class Record private (cells: Map[ColumnDef, Any])
     */
   def get[T](columnDef: TypedColumnDef[T]): Option[T] =
     if(data.contains(columnDef))
-      Some(data(columnDef).asInstanceOf[T])
+      Option(data(columnDef).asInstanceOf[T])
     else
       None
 


### PR DESCRIPTION
<!-- Optional: -->
Fixes #11 

## Proposed Changes

  - Wraps possible null value in `Record` using `Option` instead of `Some`, this results in `None` if the value is null and `Some(actualValue)` else
- Formerly `Some(null)` results were possible which could result in an NPE especially likely when using the `RowRelation` which directly uses `Record`'s (see #11)

## Related

  - based on #11 
