### PR TITLE
Adding projection (SELECT) to Record and Relations

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Exceptions.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Exceptions.scala
@@ -1,0 +1,19 @@
+package de.up.hpi.informationsystems.adbms.definition
+
+
+sealed class AdbmsException(message: String) extends Exception(message) {
+  def this(message: String, cause: Throwable) = {
+    this(message)
+    initCause(cause)
+  }
+
+  def this(cause: Throwable) = this(cause.toString, cause)
+
+  def this() = this(null: String)
+}
+/**
+  * Indicates that the supplied column definition is not applicable to the current schema.
+  *
+  * @param message gives details
+  */
+case class IncompatibleColumnDefinitionException(message: String) extends AdbmsException(message)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -31,20 +31,20 @@ class Record private (cells: Map[ColumnDef, Any])
       None
 
   /**
-    * Iff `columnDefs` is a subset of this Record,
-    * performs a projection of this relation to the specified columns,
+    * Iff `columnDefs` is a subset of this record,
+    * performs a projection of this record to the specified columns,
     * or returns an error message.
     * @param columnDefs columns to project to
-    * @return Either a new record containing only the specified columns or an error message
+    * @return A new record containing only the specified columns
     */
   def project(columnDefs: Seq[ColumnDef]): Try[Record] = Try(internal_project(columnDefs))
 
   /**
-    * Iff all columns of the relation are a subset of this Record,
-    * returns a new Record with only the columns of the Relation,
+    * Iff all columns of the relation are a subset of this record,
+    * returns a new record with only the columns of the relation,
     * otherwise returns an error message.
     * @param r Relation to project this Record to
-    * @return Either a new record containing only the specified columns or an error message
+    * @return A new record containing only the specified columns
     */
   def project(r: Relation): Try[Record] = Try(internal_project(r.columns))
 

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -107,22 +107,33 @@ object Record {
   def apply(columnDefs: Seq[ColumnDef]): RecordBuilder = new RecordBuilder(columnDefs, Map.empty)
 
   /**
-    * Builder for a [[de.up.hpi.informationsystems.adbms.definition.Record]]
+    * Builder for a [[de.up.hpi.informationsystems.adbms.definition.Record]].
+    * Initiates the record builder with the column definition list the record should comply with.
     * @param columnDefs all columns of the corresponding relational schema
     */
   class RecordBuilder(columnDefs: Seq[ColumnDef], recordData: Map[ColumnDef, Any]) {
 
     /**
-      *
+      * Sets the selected cell's value.
       * @param in mapping from column to cell content
       * @tparam T value type, same as for the column definition
-      * @return the [[RecordBuilder]] itself for
+      * @return the updated [[RecordBuilder]]
       */
     def apply[T](in: (TypedColumnDef[T], T)): RecordBuilder =
       new RecordBuilder(columnDefs, recordData ++ Map(in))
 
+    /**
+      * Sets the selected cell's value.
+      * @param in mapping from column to cell content
+      * @tparam T value type, same as for the column definition
+      * @return the updated [[RecordBuilder]]
+      */
     def withCellContent[T](in: (TypedColumnDef[T], T)): RecordBuilder = apply(in)
 
+    /**
+      * Builds the [[de.up.hpi.informationsystems.adbms.definition.Record]] instance.
+      * @return a new record
+      */
     def build(): Record = {
       val data: Map[ColumnDef, Any] = columnDefs
         .map{ colDef => Map(colDef -> recordData.getOrElse(colDef, null)) }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -29,6 +29,11 @@ class Record private (cells: Map[ColumnDef, Any])
     else
       None
 
+  def project(columnDefs: Seq[ColumnDef]): Either[String, Record] =
+    if(columnDefs.toSet subsetOf columns.toSet)
+      Right(new Record(data.filterKeys(columnDefs.contains)))
+    else
+      Left(s"this record does not contain all specified columns {$columnDefs}")
 
   // from MapLike
   override def empty: Record = new Record(Map.empty)
@@ -110,6 +115,7 @@ object Record {
     * Builder for a [[de.up.hpi.informationsystems.adbms.definition.Record]].
     * Initiates the record builder with the column definition list the record should comply with.
     * @param columnDefs all columns of the corresponding relational schema
+    * @param recordData initial cell contents, usually: `Map.empty`
     */
   class RecordBuilder(columnDefs: Seq[ColumnDef], recordData: Map[ColumnDef, Any]) {
 
@@ -134,11 +140,14 @@ object Record {
       * Builds the [[de.up.hpi.informationsystems.adbms.definition.Record]] instance.
       * @return a new record
       */
-    def build(): Record = {
-      val data: Map[ColumnDef, Any] = columnDefs
-        .map{ colDef => Map(colDef -> recordData.getOrElse(colDef, null)) }
-        .reduce( _ ++ _)
-      new Record(data)
-    }
+    def build(): Record =
+      if(columnDefs.isEmpty)
+        new Record(Map.empty)
+      else {
+        val data: Map[ColumnDef, Any] = columnDefs
+          .map{ colDef => Map(colDef -> recordData.getOrElse(colDef, null)) }
+          .reduce( _ ++ _)
+        new Record(data)
+      }
   }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -29,11 +29,28 @@ class Record private (cells: Map[ColumnDef, Any])
     else
       None
 
+  /**
+    * Iff `columnDefs` is a subset of this Record,
+    * performs a projection of this relation to the specified columns,
+    * or returns an error message.
+    * @param columnDefs columns to project to
+    * @return Either a new record containing only the specified columns or an error message
+    */
   def project(columnDefs: Seq[ColumnDef]): Either[String, Record] =
     if(columnDefs.toSet subsetOf columns.toSet)
       Right(new Record(data.filterKeys(columnDefs.contains)))
     else
       Left(s"this record does not contain all specified columns {$columnDefs}")
+
+  /**
+    * Iff all columns of the relation are a subset of this Record,
+    * returns a new Record with only the columns of the Relation,
+    * otherwise returns an error message.
+    * @param r Relation to project this Record to
+    * @return Either a new record containing only the specified columns or an error message
+    */
+  def project(r: Relation): Either[String, Record] =
+    project(r.columns)
 
   // from MapLike
   override def empty: Record = new Record(Map.empty)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -2,6 +2,8 @@ package de.up.hpi.informationsystems.adbms.definition
 
 import de.up.hpi.informationsystems.adbms.definition.Record.RecordBuilder
 
+import scala.util.Try
+
 trait Relation {
 
   /**
@@ -32,6 +34,15 @@ trait Relation {
     */
   def whereAll(fs: Map[ColumnDef, Any => Boolean]): Seq[Record]
 
+  /**
+    * Iff `columnDefs` is a subset of this relation's column definition set,
+    * performs a projection of this relation to the specified columns,
+    * or returns an error message.
+    * @param columnDefs columns to project to
+    * @return All records containing only the specified columns
+    */
+  def project(columnDefs: Seq[ColumnDef]): Try[Seq[Record]]
+
 
   // this trait comes with this for nothing :)
   /**
@@ -47,5 +58,12 @@ trait Relation {
     */
   def insertAll(records: Seq[Record]): Unit = records.foreach(insert)
 
-
+  /**
+    * Iff all columns of the other relation are a subset of this relation's columns,
+    * returns all records with only the columns of the other relation,
+    * otherwise returns an error message.
+    * @param r Relation to project this relation to
+    * @return All records containing only the specified columns
+    */
+  def project(r: Relation): Try[Seq[Record]] = project(r.columns)
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -1,4 +1,5 @@
 package de.up.hpi.informationsystems.adbms.definition
+import scala.util.Try
 
 sealed trait RowRelation extends Relation
 
@@ -69,11 +70,18 @@ object RowRelation {
           .forall(_ == true)
       }
 
+    override def project(columnDefs: Seq[ColumnDef]): Try[Seq[Record]] = Try(
+      if(columnDefs.toSet subsetOf columns.toSet)
+        data.map(_.project(columnDefs).get)
+      else
+        throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
+    )
+
     /** @inheritdoc */
     override def toString: String = {
       val header = columns.map { c => s"${c.name}[${c.tpe}]" }.mkString(" | ")
       val line = "-" * header.length
-      var content = data.map(_.values.mkString(" | ")).mkString("\n")
+      val content = data.map(_.values.mkString(" | ")).mkString("\n")
       header + "\n" + line + "\n" + content + "\n" + line + "\n"
     }
   }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -1,0 +1,62 @@
+package de.up.hpi.informationsystems.adbms.definition
+
+import org.scalatest.{Matchers, WordSpec}
+
+class RecordTest extends WordSpec with Matchers {
+
+  "A record" when {
+    "empty" should {
+      val emptyRecord = Record(Seq.empty).build()
+
+      "have an empty column list" in {
+        emptyRecord.columns shouldBe empty
+      }
+
+      "not return any data" in {
+        emptyRecord.get(ColumnDef[Any]("")) shouldBe empty
+      }
+
+      "project to itself, when projected by an empty list" in {
+        emptyRecord.project(Seq.empty) should equal(Right(emptyRecord))
+      }
+
+      "not allow projection, when projecting by any column definition" in {
+        emptyRecord.project(Seq(ColumnDef[Any](""))) should be.leftSideValue
+      }
+    }
+
+    "empty with column definitions" should {
+      val col1 = ColumnDef[String]("col1")
+      val col2 = ColumnDef[Int]("col2")
+      val col3 = ColumnDef[Double]("col3")
+      val record = Record(Seq(col1, col2, col3)).build()
+
+      "have a column list" in {
+        record.columns.size shouldBe 3
+        record.columns shouldEqual Seq(col1, col2, col3)
+      }
+
+      "return None, when accessing any column" in {
+        record.get(ColumnDef[Any]("")) shouldBe None
+        record.get(col1) shouldBe None
+        record.get(col2) shouldBe None
+        record.get(col3) shouldBe None
+      }
+
+      "project to empty record, when projected by an empty list" in {
+        record.project(Seq.empty) should equal(Right(Record(Seq.empty).build()))
+      }
+
+      "not allow projection, when projecting by any column definition" in {
+        record.project(Seq(ColumnDef[Any](""))) should be.leftSideValue
+      }
+
+      "project to correct column subset, when projecting by contained columns" in {
+        record.project(Seq(col1)) should equal(Right(Record(Seq(col1)).build()))
+        record.project(Seq(col2)) should equal(Right(Record(Seq(col2)).build()))
+        record.project(Seq(col1, col3)) should equal(Right(Record(Seq(col1, col3)).build()))
+      }
+    }
+  }
+
+}

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -22,6 +22,7 @@ class RecordTest extends WordSpec with Matchers {
 
       "not allow projection, when projecting by any column definition" in {
         emptyRecord.project(Seq(ColumnDef[Any](""))) should be.leftSideValue
+        emptyRecord.project(RowRelation(Seq(ColumnDef[Any]("")))) should be.leftSideValue
       }
     }
 
@@ -30,6 +31,7 @@ class RecordTest extends WordSpec with Matchers {
       val col2 = ColumnDef[Int]("col2")
       val col3 = ColumnDef[Double]("col3")
       val record = Record(Seq(col1, col2, col3)).build()
+      val R = RowRelation(Seq(col1, col2))
 
       "have a column list" in {
         record.columns.size shouldBe 3
@@ -55,6 +57,7 @@ class RecordTest extends WordSpec with Matchers {
         record.project(Seq(col1)) should equal(Right(Record(Seq(col1)).build()))
         record.project(Seq(col2)) should equal(Right(Record(Seq(col2)).build()))
         record.project(Seq(col1, col3)) should equal(Right(Record(Seq(col1, col3)).build()))
+        record.project(R) should equal(Right(Record(Seq(col1, col2)).build()))
       }
     }
   }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -2,6 +2,8 @@ package de.up.hpi.informationsystems.adbms.definition
 
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.util.{Success, Failure}
+
 class RecordTest extends WordSpec with Matchers {
 
   "A record" when {
@@ -17,12 +19,12 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to itself, when projected by an empty list" in {
-        emptyRecord.project(Seq.empty) should equal(Right(emptyRecord))
+        emptyRecord.project(Seq.empty) should equal(Success(emptyRecord))
       }
 
       "not allow projection, when projecting by any column definition" in {
-        emptyRecord.project(Seq(ColumnDef[Any](""))).isLeft shouldBe true
-        emptyRecord.project(RowRelation(Seq(ColumnDef[Any]("")))).isLeft shouldBe true
+        emptyRecord.project(Seq(ColumnDef[Any](""))).isFailure shouldBe true
+        emptyRecord.project(RowRelation(Seq(ColumnDef[Any]("")))).isFailure shouldBe true
       }
     }
 
@@ -46,7 +48,7 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to empty record, when projected by an empty list" in {
-        record.project(Seq.empty) should equal(Right(Record(Seq.empty).build()))
+        record.project(Seq.empty) should equal(Success(Record(Seq.empty).build()))
       }
 
       "not allow projection, when projecting by any column definition" in {
@@ -54,10 +56,10 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to correct column subset, when projecting by contained columns" in {
-        record.project(Seq(col1)) should equal(Right(Record(Seq(col1)).build()))
-        record.project(Seq(col2)) should equal(Right(Record(Seq(col2)).build()))
-        record.project(Seq(col1, col3)) should equal(Right(Record(Seq(col1, col3)).build()))
-        record.project(R) should equal(Right(Record(Seq(col1, col2)).build()))
+        record.project(Seq(col1)) should equal(Success(Record(Seq(col1)).build()))
+        record.project(Seq(col2)) should equal(Success(Record(Seq(col2)).build()))
+        record.project(Seq(col1, col3)) should equal(Success(Record(Seq(col1, col3)).build()))
+        record.project(R) should equal(Success(Record(Seq(col1, col2)).build()))
       }
     }
 
@@ -84,18 +86,18 @@ class RecordTest extends WordSpec with Matchers {
 
       "retain values of projected columns and drop others" in {
         record.project(Seq(col1)) match {
-          case Right(r) =>
+          case Success(r) =>
             r.get(col1) shouldBe Some(val1)
             r.get(col2) shouldBe None
             r.get(col3) shouldBe None
-          case Left(_) => fail("Projection by column sequence failed, but it should succeed")
+          case Failure(_) => fail("Projection by column sequence failed, but it should succeed")
         }
         record.project(R) match {
-          case Right(r) =>
+          case Success(r) =>
             r.get(col1) shouldBe Some(val1)
             r.get(col2) shouldBe Some(val2)
             r.get(col3) shouldBe None
-          case Left(_) => fail("Projection by Relation failed, but it should succeed")
+          case Failure(_) => fail("Projection by Relation failed, but it should succeed")
         }
       }
     }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -92,6 +92,8 @@ object TestApplication extends App {
     .withCellContent(colLastname -> "")
     .build()
   println(record)
+  assert(record.project(Seq(colAge)) == Right(Record(Seq(colAge))(colAge -> 45).build()))
+  assert(record.project(Seq(colAge, colCustomerDiscount)).isLeft)
 
   println(R2.columns.mkString(", "))
   println()

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -2,6 +2,8 @@ package de.up.hpi.informationsystems.sampleapp
 
 import de.up.hpi.informationsystems.adbms.definition._
 
+import scala.util.Success
+
 object TestApplication extends App {
 
   implicit class RecordSeqToString(a: Seq[Record]) {
@@ -79,6 +81,10 @@ object TestApplication extends App {
   assert(ColumnDef[String]("Firstname") == colFirstname)
   assert(ColumnDef[Int]("Firstname").asInstanceOf[ColumnDef] != colFirstname.asInstanceOf[ColumnDef])
 
+  println()
+  println("Projection of user relation:")
+  println(R.project(Seq(colFirstname, colLastname)).getOrElse(Seq.empty).pretty)
+
 
   /**
     * Testing Customer relation => RowStore
@@ -92,8 +98,8 @@ object TestApplication extends App {
     .withCellContent(colLastname -> "")
     .build()
   println(record)
-  assert(record.project(Seq(colAge)) == Right(Record(Seq(colAge))(colAge -> 45).build()))
-  assert(record.project(Seq(colAge, colCustomerDiscount)).isLeft)
+  assert(record.project(Seq(colAge)) == Success(Record(Seq(colAge))(colAge -> 45).build()))
+  assert(record.project(Seq(colAge, colCustomerDiscount)).isFailure)
 
   println(R2.columns.mkString(", "))
   println()
@@ -138,4 +144,8 @@ object TestApplication extends App {
       )
       .pretty
   )
+
+  println()
+  println("Projection of customer relation:")
+  println(R2.project(Seq(colCustomerName, colCustomerDiscount)).getOrElse(Seq.empty).pretty)
 }


### PR DESCRIPTION
## Proposed Changes

  - capability to project `Record`s and `Relation`s
    - `record.project(Seq(colDef1, colDef2))`
    - `R.project(Seq(colDef1, colDef2))`
    - `record.project(R)` and `R2.project(R)`
  - all project-methods return a `Try[<result_type]`
  - tests for `Record` class (`RecordBuilder` is tested implicitly)

