### PR TITLE
Fix Optional instantiation formerly using Some()

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnStore.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnStore.scala
@@ -79,7 +79,7 @@ private[definition] class TypedColumnStore[T](columnDefInt: ColumnDef[T]) extend
 
   override def get(idx: Int): Option[T] =
     if(idx < data.length && idx >= 0)
-      Some(data(idx))
+      Option(data(idx))
     else
       None
 


### PR DESCRIPTION
## Proposed Changes

  - Change `Some(...)` to `Option(...)` which is the appropriate way to instantiate an *optional* since `Some( some_that_might_be_null )` could end up being `Some(null)` instead of the correct `None`

## Related

  - #11 : This - now closed - issue could be tracked back to using `Some` to instantiate an *optional* as well
