### PR TITLE
Refactor Relation API to favor inheritance

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnRelation.scala
@@ -2,110 +2,69 @@ package de.up.hpi.informationsystems.adbms.definition
 import scala.util.Try
 
 
-sealed trait ColumnRelation extends Relation
-
 /**
-  * Defines a column-oriented relation schema, which's store gets automatically generated.
+  * Defines a column-oriented relation schema, which's data store gets automatically generated.
   */
-object ColumnRelation {
+abstract class ColumnRelation extends Relation {
 
-  /**
-    * Defines a column-oriented relation schema, which gets automatically generated.
-    *
-    * @param columnDefs sequence of column definitions
-    * @return the generated column-oriented relational store
-    */
-  def apply(columnDefs: Seq[UntypedColumnDef]): ColumnRelation = new ColumnRelationStore(columnDefs)
+  // needs to be lazy evaluated, because `columns` is not yet defined when this class gets instantiated
+  private lazy val data: Map[UntypedColumnDef, ColumnStore] =
+    columns.map { colDef: UntypedColumnDef =>
+      Map(colDef -> colDef.buildColumnStore())
+    }.reduce(_ ++ _)
 
-  /**
-    * Indicates that a [[de.up.hpi.informationsystems.adbms.definition.UntypedColumnDef]] was not found in
-    * the column relation.
-    *
-    * @param message gives details
-    */
-  class ColumnNotFoundException(message: String) extends Exception(message) {
-    def this(message: String, cause: Throwable) = {
-      this(message)
-      initCause(cause)
-    }
-
-    def this(cause: Throwable) = this(cause.toString, cause)
-
-    def this() = this(null: String)
-  }
-
-  /**
-    * Private (hidden) implementation of the [[de.up.hpi.informationsystems.adbms.definition.ColumnRelation]] trait.
-    * @param colDefs column definitions used to construct the underlying data store
-    */
-  private final class ColumnRelationStore(private val colDefs: Seq[UntypedColumnDef]) extends ColumnRelation {
-
-    private val data: Map[UntypedColumnDef, ColumnStore] =
-      colDefs.map { colDef: UntypedColumnDef =>
-        Map(colDef -> colDef.buildColumnStore())
-      }.reduce(_ ++ _)
-
-    private var n: Int = 0
-
-    private def getRecord(selectedColumns: Seq[UntypedColumnDef])(idx: Int): Record = {
-      selectedColumns
-        .foldLeft( Record(selectedColumns) )( (builder, column) => {
-          val columnStore = data(column) // needed to get the right type here 🡫
-          builder.withCellContent(column.asInstanceOf[ColumnDef[columnStore.valueType]])(columnStore(idx))
-        })
-        .build()
-    }
-
-
-    /** @inheritdoc */
-    override def columns: Seq[UntypedColumnDef] = colDefs
-
-    /** @inheritdoc */
-    override def insert(record: Record): Unit = {
-      n += 1
-      columns.foreach(column => {
-        val columnStore = data(column)
-        columnStore.append(record(column).asInstanceOf[columnStore.valueType])
+  private def getRecord(selectedColumns: Seq[UntypedColumnDef])(idx: Int): Record = {
+    selectedColumns
+      .foldLeft( Record(selectedColumns) )( (builder, column) => {
+        val columnStore = data(column) // needed to get the right type here 🡫
+        builder.withCellContent(column.asInstanceOf[ColumnDef[columnStore.valueType]])(columnStore(idx))
       })
-    }
-
-    /** @inheritdoc */
-    override def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record] = {
-      val columnStore = data(f._1.untyped) // needed to get the right type 2 lines below
-      columnStore
-        .indicesWhere(f._2.asInstanceOf[columnStore.valueType => Boolean])
-        .map(getRecord(columns)(_))
-    }
-
-    /** @inheritdoc */
-    override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Seq[Record] =
-      fs.keys
-        .map(column =>
-          data(column)
-            .indicesWhere(fs(column))
-            .map(getRecord(columns)(_))
-            .toSet
-        ).reduce( (a1, a2) => a1.intersect(a2) )
-        .toSeq
-
-    /** @inheritdoc */
-    override def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]] = Try(
-      if(columnDefs.toSet subsetOf columns.toSet)
-        (0 until data.size).map(getRecord(columnDefs)(_))
-      else
-        throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
-    )
-
-    override def toString: String = {
-      val header = columns.map { c => s"${c.name}[${c.tpe}]" }.mkString(" | ")
-      val line = "-" * header.length
-      var content: String = ""
-      for (i <- 0 to n) {
-        val col: Seq[ColumnStore] = columns.map(data)
-        content = content + col.map(_.get(i)).mkString(" | ") + "\n"
-      }
-      header + "\n" + line + "\n" + content + "\n" + line + "\n"
-    }
+      .build()
   }
 
+  /** @inheritdoc */
+  override def insert(record: Record): Unit = {
+    columns.foreach(column => {
+      val columnStore = data(column)
+      columnStore.append(record(column).asInstanceOf[columnStore.valueType])
+    })
+  }
+
+  /** @inheritdoc */
+  override def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record] = {
+    val columnStore = data(f._1.untyped) // needed to get the right type 2 lines below
+    columnStore
+      .indicesWhere(f._2.asInstanceOf[columnStore.valueType => Boolean])
+      .map(getRecord(columns)(_))
+  }
+
+  /** @inheritdoc */
+  override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Seq[Record] =
+    fs.keys
+      .map(column =>
+        data(column)
+          .indicesWhere(fs(column))
+          .map(getRecord(columns)(_))
+          .toSet
+      ).reduce( (a1, a2) => a1.intersect(a2) )
+      .toSeq
+
+  /** @inheritdoc */
+  override def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]] = Try(
+    if(columnDefs.toSet subsetOf columns.toSet)
+      (0 until data.size).map(getRecord(columnDefs)(_))
+    else
+      throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
+  )
+
+  override def toString: String = {
+    val header = columns.map { c => s"${c.name}[${c.tpe}]" }.mkString(" | ")
+    val line = "-" * header.length
+    var content: String = ""
+    for (i <- 0 to data.size) {
+      val col: Seq[ColumnStore] = columns.map(data)
+      content = content + col.map(_.get(i)).mkString(" | ") + "\n"
+    }
+    header + "\n" + line + "\n" + content + "\n" + line + "\n"
+  }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -8,6 +8,7 @@ trait Relation {
 
   /**
     * Returns the column definitions of this relation.
+    * @note override this value to define your relational schema
     * @return a sequence of column definitions
     */
   def columns: Seq[UntypedColumnDef]

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -1,89 +1,48 @@
 package de.up.hpi.informationsystems.adbms.definition
 import scala.util.Try
 
-sealed trait RowRelation extends Relation
+abstract class RowRelation extends Relation {
 
+  private var data: Seq[Record] = Seq.empty
 
-/**
-  * Defines a row-oriented relational schema, which's store gets automatically generated.
-  */
-object RowRelation {
+  /** @inheritdoc */
+  override def insert(record: Record): Unit = data = data :+ record
 
-  /**
-    * Defines a row-oriented relational schema, which gets automatically generated.
-    *
-    * @param columnDefs sequence of column definitions
-    * @return the generated row-oriented relational store
-    */
-  def apply(columnDefs: Seq[UntypedColumnDef]): RowRelation = new RowRelationStore(columnDefs)
+  /** @inheritdoc */
+  override def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record] =
+    data.filter{ record => record.get[T](f._1).exists(f._2) }
 
-  /**
-    * Indicates that a [[de.up.hpi.informationsystems.adbms.definition.UntypedColumnDef]] was not found in
-    * the row relation.
-    *
-    * @param message gives details
-    */
-  class ColumnNotFoundException(message: String) extends Exception(message) {
-    def this(message: String, cause: Throwable) = {
-      this(message)
-      initCause(cause)
-    }
-
-    def this(cause: Throwable) = this(cause.toString, cause)
-
-    def this() = this(null: String)
-  }
-
-  /**
-    * Private (hidden) implementation of the [[de.up.hpi.informationsystems.adbms.definition.RowRelation]] trait.
-    * @param colDefs column definitions used to construct the underlying data store
-    */
-  private final class RowRelationStore(private val colDefs: Seq[UntypedColumnDef]) extends RowRelation {
-
-    private var data: Seq[Record] = Seq.empty
-
-    /** @inheritdoc */
-    override def columns: Seq[UntypedColumnDef] = colDefs
-
-    /** @inheritdoc */
-    override def insert(record: Record): Unit = data = data :+ record
-
-    /** @inheritdoc */
-    override def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record] =
-      data.filter{ record => record.get[T](f._1).exists(f._2) }
-
-    /** @inheritdoc */
-    override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Seq[Record] =
-      // filter all records
-      data.filter{ record =>
-        fs.keys
-          // map over all supplied filters (key = column)
-          .map { col: UntypedColumnDef =>
-            /* `val rVal = record(col)` returns the value in the record for the column `col`
-             * `val filterF = fs(col)` returns the filter for column `col`
-             * `val res = filterF(rVal)` applies the filter to the value of the record and corresponding column,
-             * returning `true` or `false`
-             */
-            fs(col)(record(col))
-          }
-          // test if all filters for this record are true
-          .forall(_ == true)
+  /** @inheritdoc */
+  override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Seq[Record] =
+    // filter all records
+    data.filter{ record =>
+      fs.keys
+        // map over all supplied filters (key = column)
+        .map { col: UntypedColumnDef =>
+        /* `val rVal = record(col)` returns the value in the record for the column `col`
+         * `val filterF = fs(col)` returns the filter for column `col`
+         * `val res = filterF(rVal)` applies the filter to the value of the record and corresponding column,
+         * returning `true` or `false`
+         */
+        fs(col)(record(col))
       }
-
-    override def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]] = Try(
-      if(columnDefs.toSet subsetOf columns.toSet)
-        data.map(_.project(columnDefs).get)
-      else
-        throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
-    )
-
-    /** @inheritdoc */
-    override def toString: String = {
-      val header = columns.map { c => s"${c.name}[${c.tpe}]" }.mkString(" | ")
-      val line = "-" * header.length
-      val content = data.map(_.values.mkString(" | ")).mkString("\n")
-      header + "\n" + line + "\n" + content + "\n" + line + "\n"
+        // test if all filters for this record are true
+        .forall(_ == true)
     }
-  }
 
+  /** @inheritdoc */
+  override def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]] = Try(
+    if(columnDefs.toSet subsetOf columns.toSet)
+      data.map(_.project(columnDefs).get)
+    else
+      throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
+  )
+
+  /** @inheritdoc */
+  override def toString: String = {
+    val header = columns.map { c => s"${c.name}[${c.tpe}]" }.mkString(" | ")
+    val line = "-" * header.length
+    val content = data.map(_.values.mkString(" | ")).mkString("\n")
+    header + "\n" + line + "\n" + content + "\n" + line + "\n"
+  }
 }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -65,7 +65,9 @@ class RecordTest extends WordSpec with Matchers {
 
       "not allow projection, when projecting by any column definition" in {
         emptyRecord.project(Seq(ColumnDef[Any](""))).isFailure shouldBe true
-        emptyRecord.project(RowRelation(Seq(ColumnDef[Any]("")))).isFailure shouldBe true
+        emptyRecord.project(new RowRelation {
+          override def columns: Seq[UntypedColumnDef] = Seq(ColumnDef[Any](""))
+        }).isFailure shouldBe true
       }
     }
 
@@ -74,7 +76,9 @@ class RecordTest extends WordSpec with Matchers {
       val col2 = ColumnDef[Int]("col2")
       val col3 = ColumnDef[Double]("col3")
       val record = Record(Seq(col1, col2, col3)).build()
-      val R = RowRelation(Seq(col1, col2))
+      val R = new RowRelation {
+        override def columns: Seq[UntypedColumnDef] = Seq(col1, col2)
+      }
 
       "have a column list" in {
         record.columns.size shouldBe 3
@@ -116,7 +120,9 @@ class RecordTest extends WordSpec with Matchers {
         .withCellContent(col2)(val2)
         .withCellContent(col3)(val3)
         .build()
-      val R = RowRelation(Seq(col1, col2))
+      val R = new RowRelation {
+        override def columns: Seq[UntypedColumnDef] = Seq(col1, col2)
+      }
 
       "return the column's cell value" in {
         record.get(ColumnDef[Any]("")) shouldBe None

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -15,75 +15,73 @@ object TestApplication extends App {
   /**
     * Definition of Columns and Relations for relation "User"
     */
-  object UserRelationDefinition {
+  object User extends ColumnRelation {
     val colFirstname: ColumnDef[String] = ColumnDef("Firstname")
     val colLastname: ColumnDef[String] = ColumnDef("Lastname")
     val colAge: ColumnDef[Int] = ColumnDef("Age")
 
-    val R: ColumnRelation = ColumnRelation(Seq(colFirstname, colLastname, colAge))
+    override val columns: Seq[UntypedColumnDef] = Seq(colFirstname, colLastname, colAge)
   }
 
   /**
     * Definition of Columns and Relations for relation "Customer"
     */
-  object CustomerRelationDefinition {
-    val colCustomerId: ColumnDef[Int] = ColumnDef("Id")
-    val colCustomerName: ColumnDef[String] = ColumnDef("Name")
-    val colCustomerDiscount: ColumnDef[Double] = ColumnDef("Discount")
+  object Customer extends RowRelation {
+    val colId: ColumnDef[Int] = ColumnDef("Id")
+    val colName: ColumnDef[String] = ColumnDef("Name")
+    val colDiscount: ColumnDef[Double] = ColumnDef("Discount")
 
-    val R: RowRelation = RowRelation(Seq(colCustomerId, colCustomerName, colCustomerDiscount))
+    override val columns: Seq[UntypedColumnDef] = Seq(colId, colName, colDiscount)
   }
 
-  import UserRelationDefinition._
-  import CustomerRelationDefinition.{R => R2, colCustomerDiscount, colCustomerId, colCustomerName}
 
   /**
     * Testing User relation => ColumnStore
     */
 
-  println(R.columns.mkString(", "))
-  R.insert(
-    Record(R.columns)
-      .withCellContent(colLastname)("Maier")
-      .withCellContent(colFirstname)("Hans")
-      .withCellContent(colAge)(33)
+  println(User.columns.mkString(", "))
+  User.insert(
+    Record(User.columns)
+      .withCellContent(User.colLastname)("Maier")
+      .withCellContent(User.colFirstname)("Hans")
+      .withCellContent(User.colAge)(33)
       .build()
   )
-  R.insert(
-    Record(R.columns)
-      .withCellContent(colFirstname)("Hans")
-      .withCellContent(colLastname)("Schneider")
-      .withCellContent(colAge)(12)
+  User.insert(
+    Record(User.columns)
+      .withCellContent(User.colFirstname)("Hans")
+      .withCellContent(User.colLastname)("Schneider")
+      .withCellContent(User.colAge)(12)
       .build()
   )
-  R.insert(
-    Record(R.columns)
-      .withCellContent(colFirstname)("Justus")
-      .withCellContent(colLastname)("Jonas")
+  User.insert(
+    Record(User.columns)
+      .withCellContent(User.colFirstname)("Justus")
+      .withCellContent(User.colLastname)("Jonas")
       .build()
   )
   println()
-  println(R)
+  println(User)
 
   println()
   println("where:")
   println(
-    R.where[String](colFirstname -> { _ == "Hans" }).pretty
+    User.where[String](User.colFirstname -> { _ == "Hans" }).pretty
   )
   println("whereAll:")
   println(
-    R.whereAll(
-      Map(colFirstname.untyped -> { name: Any => name.asInstanceOf[String] == "Hans" })
-      ++ Map(colAge.untyped -> { age: Any => age.asInstanceOf[Int] == 33 })
+    User.whereAll(
+      Map(User.colFirstname.untyped -> { name: Any => name.asInstanceOf[String] == "Hans" })
+      ++ Map(User.colAge.untyped -> { age: Any => age.asInstanceOf[Int] == 33 })
     ).pretty
   )
 
-  assert(ColumnDef[String]("Firstname") == colFirstname)
-  assert(ColumnDef[Int]("Firstname").untyped != colFirstname.untyped)
+  assert(ColumnDef[String]("Firstname") == User.colFirstname)
+  assert(ColumnDef[Int]("Firstname").untyped != User.colFirstname.untyped)
 
   println()
   println("Projection of user relation:")
-  println(R.project(Seq(colFirstname, colLastname)).getOrElse(Seq.empty).pretty)
+  println(User.project(Seq(User.colFirstname, User.colLastname)).getOrElse(Seq.empty).pretty)
 
 
   /**
@@ -93,43 +91,43 @@ object TestApplication extends App {
   println()
   println()
   import Record.implicits._
-  val record = Record(R.columns)(
-      colFirstname ~> "Hans" &
-      colLastname ~> "Lastname" &
-      colAge ~> 45
+  val record = Record(User.columns)(
+      User.colFirstname ~> "Hans" &
+      User.colLastname ~> "Lastname" &
+      User.colAge ~> 45
     )
     .build()
   println(record)
-  assert(record.project(Seq(colAge)) == Success(Record(Seq(colAge)).withCellContent(colAge)(45).build()))
-  assert(record.project(Seq(colAge, colCustomerDiscount)).isFailure)
+  assert(record.project(Seq(User.colAge)) == Success(Record(Seq(User.colAge))(User.colAge ~> 45).build()))
+  assert(record.project(Seq(User.colAge, Customer.colDiscount)).isFailure)
 
-  println(R2.columns.mkString(", "))
+  println(Customer.columns.mkString(", "))
   println()
-  R2.insert(
-    Record(R2.columns)
-      .withCellContent(colCustomerId)(1)
-      .withCellContent(colCustomerName)("BMW")
+  Customer.insert(
+    Record(Customer.columns)
+      .withCellContent(Customer.colId)(1)
+      .withCellContent(Customer.colName)("BMW")
       .build()
   )
-  R2.insert(
-    Record(R2.columns)
-      .withCellContent(colCustomerId)(2)
-      .withCellContent(colCustomerName)("BMW Group")
-      .withCellContent(colCustomerDiscount)(0.023)
+  Customer.insert(
+    Record(Customer.columns)
+      .withCellContent(Customer.colId)(2)
+      .withCellContent(Customer.colName)("BMW Group")
+      .withCellContent(Customer.colDiscount)(0.023)
       .build()
   )
-  R2.insert(
-    Record(R2.columns)
-      .withCellContent(colCustomerId)(3)
-      .withCellContent(colCustomerName)("Audi AG")
-      .withCellContent(colCustomerDiscount)(0.05)
+  Customer.insert(
+    Record(Customer.columns)
+      .withCellContent(Customer.colId)(3)
+      .withCellContent(Customer.colName)("Audi AG")
+      .withCellContent(Customer.colDiscount)(0.05)
       .build()
   )
 
-  println(R2)
+  println(Customer)
   println("where:")
   println(
-    R2.where[String](colCustomerName -> { _.contains("BMW") }).pretty
+    Customer.where[String](Customer.colName -> { _.contains("BMW") }).pretty
   )
 
   val isBMW: Any => Boolean = value =>
@@ -140,14 +138,14 @@ object TestApplication extends App {
 
   println("whereAll:")
   println(
-    R2.whereAll(
-        Map(colCustomerName.untyped -> isBMW)
-          ++ Map(colCustomerDiscount.untyped -> discountGreaterThan(0.01))
+    Customer.whereAll(
+        Map(Customer.colName.untyped -> isBMW)
+          ++ Map(Customer.colDiscount.untyped -> discountGreaterThan(0.01))
       )
       .pretty
   )
 
   println()
   println("Projection of customer relation:")
-  println(R2.project(Seq(colCustomerName, colCustomerDiscount)).getOrElse(Seq.empty).pretty)
+  println(Customer.project(Seq(Customer.colName, Customer.colDiscount)).getOrElse(Seq.empty).pretty)
 }


### PR DESCRIPTION
## Proposed Changes

- Removed companion objects for `ColumnRelation` and `RowRelation`
- Relations can't be instantiated any more
- `ColumnRelation` and `RowRelation` are abstract classes with one abstract member: `def columns: Seq[UntypedColumnDef]`
- new Relation definition pattern:

```scala
object User extends RowRelation {
    val colFirstname: ColumnDef[String] = ColumnDef("Firstname")
    val colLastname: ColumnDef[String] = ColumnDef("Lastname")
    val colAge: ColumnDef[Int] = ColumnDef("Age")

    override val columns: Seq[UntypedColumnDef] = Seq(colFirstname, colLastname, colAge)
}

import Record.implicits._
val record = Record(User.columns)(
    User.colFirstname ~> "Hans" &
    User.colLastname ~> "Lastname" &
    User.colAge ~> 45
  ).build()
User.insert(record)
val result: Seq[Record] = User.where[String](User.colFirstname -> { _ == "Hans" })
```