### PR TITLE
Use Set instead of Seq for columns in Records and Relations

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
@@ -4,9 +4,13 @@ package definition
 import java.util.Objects
 
 import scala.reflect.ClassTag
+import scala.language.implicitConversions
 
 object ColumnDef {
   def apply[T](name: String)(implicit ct: ClassTag[T]): ColumnDef[T] = new ColumnDef[T](name)(ct)
+
+  implicit def columnDefSet2UntypedSet[T](set: Set[ColumnDef[T]]): Set[UntypedColumnDef] =
+    set.asInstanceOf[Set[UntypedColumnDef]]
 }
 
 /**

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnRelation.scala
@@ -13,7 +13,7 @@ abstract class ColumnRelation extends Relation {
       Map(colDef -> colDef.buildColumnStore())
     }.reduce(_ ++ _)
 
-  private def getRecord(selectedColumns: Seq[UntypedColumnDef])(idx: Int): Record = {
+  private def getRecord(selectedColumns: Set[UntypedColumnDef])(idx: Int): Record = {
     selectedColumns
       .foldLeft( Record(selectedColumns) )( (builder, column) => {
         val columnStore = data(column) // needed to get the right type here 🡫
@@ -50,8 +50,8 @@ abstract class ColumnRelation extends Relation {
       .toSeq
 
   /** @inheritdoc */
-  override def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]] = Try(
-    if(columnDefs.toSet subsetOf columns.toSet)
+  override def project(columnDefs: Set[UntypedColumnDef]): Try[Seq[Record]] = Try(
+    if(columnDefs subsetOf columns)
       (0 until data.size).map(getRecord(columnDefs)(_))
     else
       throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
@@ -62,7 +62,7 @@ abstract class ColumnRelation extends Relation {
     val line = "-" * header.length
     var content: String = ""
     for (i <- 0 to data.size) {
-      val col: Seq[ColumnStore] = columns.map(data)
+      val col: Set[ColumnStore] = columns.map(data)
       content = content + col.map(_.get(i)).mkString(" | ") + "\n"
     }
     header + "\n" + line + "\n" + content + "\n" + line + "\n"

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -39,15 +39,6 @@ class Record private (cells: Map[UntypedColumnDef, Any])
     */
   def project(columnDefs: Set[UntypedColumnDef]): Try[Record] = Try(internal_project(columnDefs))
 
-  /**
-    * Iff all columns of the relation are a subset of this record,
-    * returns a new record with only the columns of the relation,
-    * otherwise returns an error message.
-    * @param r Relation to project this Record to
-    * @return A new record containing only the specified columns
-    */
-  def project(r: Relation): Try[Record] = Try(internal_project(r.columns))
-
   @throws[IncompatibleColumnDefinitionException]
   private def internal_project(columnDefs: Set[UntypedColumnDef]): Record =
     if(columnDefs subsetOf columns)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -15,7 +15,7 @@ class Record private (cells: Map[UntypedColumnDef, Any])
     * Returns column definitions in this record.
     * Alias to `keys`
     */
-  val columns: Seq[UntypedColumnDef] = cells.keys.toSeq
+  val columns: Set[UntypedColumnDef] = cells.keys.toSet
 
   /**
     * Optionally returns the cell's value of a specified column.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -37,7 +37,7 @@ class Record private (cells: Map[UntypedColumnDef, Any])
     * @param columnDefs columns to project to
     * @return A new record containing only the specified columns
     */
-  def project(columnDefs: Seq[UntypedColumnDef]): Try[Record] = Try(internal_project(columnDefs))
+  def project(columnDefs: Set[UntypedColumnDef]): Try[Record] = Try(internal_project(columnDefs))
 
   /**
     * Iff all columns of the relation are a subset of this record,
@@ -49,8 +49,8 @@ class Record private (cells: Map[UntypedColumnDef, Any])
   def project(r: Relation): Try[Record] = Try(internal_project(r.columns))
 
   @throws[IncompatibleColumnDefinitionException]
-  private def internal_project(columnDefs: Seq[UntypedColumnDef]): Record =
-    if(columnDefs.toSet subsetOf columns.toSet)
+  private def internal_project(columnDefs: Set[UntypedColumnDef]): Record =
+    if(columnDefs subsetOf columns)
       new Record(data.filterKeys(columnDefs.contains))
     else
       throw IncompatibleColumnDefinitionException(s"this record does not contain all specified columns {$columnDefs}")
@@ -127,7 +127,7 @@ object Record {
     * This call initiates the [[de.up.hpi.informationsystems.adbms.definition.Record.RecordBuilder]] with
     * the column definitions of the corresponding relational schema
     */
-  def apply(columnDefs: Seq[UntypedColumnDef]): RecordBuilder = new RecordBuilder(columnDefs, Map.empty)
+  def apply(columnDefs: Set[UntypedColumnDef]): RecordBuilder = new RecordBuilder(columnDefs, Map.empty)
 
   /**
     * Builder for a [[de.up.hpi.informationsystems.adbms.definition.Record]].
@@ -135,7 +135,7 @@ object Record {
     * @param columnDefs all columns of the corresponding relational schema
     * @param recordData initial cell contents, usually: `Map.empty`
     */
-  class RecordBuilder(columnDefs: Seq[UntypedColumnDef], recordData: Map[UntypedColumnDef, Any]) {
+  class RecordBuilder(columnDefs: Set[UntypedColumnDef], recordData: Map[UntypedColumnDef, Any]) {
 
     /**
       * Sets a cell's value using `colDef ~> &lt;value&gt;` -notation

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -58,13 +58,4 @@ trait Relation {
     * @param records to be inserted
     */
   def insertAll(records: Seq[Record]): Unit = records.foreach(insert)
-
-  /**
-    * Iff all columns of the other relation are a subset of this relation's columns,
-    * returns all records with only the columns of the other relation,
-    * otherwise returns an error message.
-    * @param r Relation to project this relation to
-    * @return All records containing only the specified columns
-    */
-  def project(r: Relation): Try[Seq[Record]] = project(r.columns)
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -4,7 +4,7 @@ import de.up.hpi.informationsystems.adbms.definition.Record.RecordBuilder
 
 import scala.util.Try
 
-abstract class Relation {
+trait Relation {
 
   /**
     * Returns the column definitions of this relation.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -51,7 +51,7 @@ trait Relation {
     * columns for this relation.
     * @return initialized RecordBuilder
     */
-  def newRecord: RecordBuilder = Record(columns.toSet)
+  def newRecord: RecordBuilder = Record(columns)
 
   /**
     * Inserts all Records into the relation.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -4,14 +4,14 @@ import de.up.hpi.informationsystems.adbms.definition.Record.RecordBuilder
 
 import scala.util.Try
 
-trait Relation {
+abstract class Relation {
 
   /**
     * Returns the column definitions of this relation.
     * @note override this value to define your relational schema
     * @return a sequence of column definitions
     */
-  def columns: Seq[UntypedColumnDef]
+  def columns: Set[UntypedColumnDef]
 
   /**
     * Inserts a [[de.up.hpi.informationsystems.adbms.definition.Record]] into the relation
@@ -42,7 +42,7 @@ trait Relation {
     * @param columnDefs columns to project to
     * @return All records containing only the specified columns
     */
-  def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]]
+  def project(columnDefs: Set[UntypedColumnDef]): Try[Seq[Record]]
 
 
   // this trait comes with this for nothing :)
@@ -51,7 +51,7 @@ trait Relation {
     * columns for this relation.
     * @return initialized RecordBuilder
     */
-  def newRecord: RecordBuilder = Record(columns)
+  def newRecord: RecordBuilder = Record(columns.toSet)
 
   /**
     * Inserts all Records into the relation.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -31,9 +31,9 @@ abstract class RowRelation extends Relation {
     }
 
   /** @inheritdoc */
-  override def project(columnDefs: Seq[UntypedColumnDef]): Try[Seq[Record]] = Try(
+  override def project(columnDefs: Set[UntypedColumnDef]): Try[Seq[Record]] = Try(
     if(columnDefs.toSet subsetOf columns.toSet)
-      data.map(_.project(columnDefs).get)
+      data.map(_.project(columnDefs.toSet).get)
     else
       throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
   )

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -32,8 +32,8 @@ abstract class RowRelation extends Relation {
 
   /** @inheritdoc */
   override def project(columnDefs: Set[UntypedColumnDef]): Try[Seq[Record]] = Try(
-    if(columnDefs.toSet subsetOf columns.toSet)
-      data.map(_.project(columnDefs.toSet).get)
+    if(columnDefs subsetOf columns)
+      data.map(_.project(columnDefs).get)
     else
       throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
   )

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -15,7 +15,7 @@ class RecordTest extends WordSpec with Matchers {
     val val3 = 3.0
 
     "build a record correctly with and without implicit" in {
-      val builder = Record(Seq(col1, col2, col3))
+      val builder = Record(Set(col1, col2, col3))
       val r1 = builder
         .withCellContent(col1)(val1)
         .withCellContent(col2)(val2)
@@ -49,7 +49,7 @@ class RecordTest extends WordSpec with Matchers {
 
   "A record" when {
     "empty" should {
-      val emptyRecord = Record(Seq.empty).build()
+      val emptyRecord = Record(Set.empty).build()
 
       "have an empty column list" in {
         emptyRecord.columns shouldBe empty
@@ -60,13 +60,13 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to itself, when projected by an empty list" in {
-        emptyRecord.project(Seq.empty) should equal(Success(emptyRecord))
+        emptyRecord.project(Set.empty: Set[UntypedColumnDef]) should equal(Success(emptyRecord))
       }
 
       "not allow projection, when projecting by any column definition" in {
-        emptyRecord.project(Seq(ColumnDef[Any](""))).isFailure shouldBe true
+        emptyRecord.project(Set(ColumnDef[Any]("")): Set[UntypedColumnDef]).isFailure shouldBe true
         emptyRecord.project(new RowRelation {
-          override def columns: Seq[UntypedColumnDef] = Seq(ColumnDef[Any](""))
+          override def columns: Set[UntypedColumnDef] = Set(ColumnDef[Any](""))
         }).isFailure shouldBe true
       }
     }
@@ -75,9 +75,9 @@ class RecordTest extends WordSpec with Matchers {
       val col1 = ColumnDef[String]("col1")
       val col2 = ColumnDef[Int]("col2")
       val col3 = ColumnDef[Double]("col3")
-      val record = Record(Seq(col1, col2, col3)).build()
+      val record = Record(Set(col1, col2, col3)).build()
       val R = new RowRelation {
-        override def columns: Seq[UntypedColumnDef] = Seq(col1, col2)
+        override def columns: Set[UntypedColumnDef] = Set(col1, col2)
       }
 
       "have a column set" in {
@@ -93,18 +93,18 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to empty record, when projected by an empty list" in {
-        record.project(Seq.empty) should equal(Success(Record(Seq.empty).build()))
+        record.project(Set.empty: Set[UntypedColumnDef]) should equal(Success(Record(Set.empty).build()))
       }
 
       "not allow projection, when projecting by any column definition" in {
-        record.project(Seq(ColumnDef[Any](""))) should be.leftSideValue
+        record.project(Set(ColumnDef[Any]("")): Set[UntypedColumnDef]) should be.leftSideValue
       }
 
       "project to correct column subset, when projecting by contained columns" in {
-        record.project(Seq(col1)) should equal(Success(Record(Seq(col1)).build()))
-        record.project(Seq(col2)) should equal(Success(Record(Seq(col2)).build()))
-        record.project(Seq(col1, col3)) should equal(Success(Record(Seq(col1, col3)).build()))
-        record.project(R) should equal(Success(Record(Seq(col1, col2)).build()))
+        record.project(Set(col1): Set[UntypedColumnDef]) should equal(Success(Record(Set(col1)).build()))
+        record.project(Set(col2): Set[UntypedColumnDef]) should equal(Success(Record(Set(col2)).build()))
+        record.project(Set(col1, col3): Set[UntypedColumnDef]) should equal(Success(Record(Set(col1, col3)).build()))
+        record.project(R) should equal(Success(Record(Set(col1, col2)).build()))
       }
     }
 
@@ -115,13 +115,13 @@ class RecordTest extends WordSpec with Matchers {
       val val1 = "val1"
       val val2 = 2
       val val3 = 3.0
-      val record = Record(Seq(col1, col2, col3))
+      val record = Record(Set(col1, col2, col3))
         .withCellContent(col1)(val1)
         .withCellContent(col2)(val2)
         .withCellContent(col3)(val3)
         .build()
       val R = new RowRelation {
-        override def columns: Seq[UntypedColumnDef] = Seq(col1, col2)
+        override def columns: Set[UntypedColumnDef] = Set(col1, col2)
       }
 
       "return the column's cell value" in {
@@ -132,7 +132,7 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "retain values of projected columns and drop others" in {
-        record.project(Seq(col1)) match {
+        record.project(Set(col1): Set[UntypedColumnDef]) match {
           case Success(r) =>
             r.get(col1) shouldBe Some(val1)
             r.get(col2) shouldBe None

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -65,9 +65,6 @@ class RecordTest extends WordSpec with Matchers {
 
       "not allow projection, when projecting by any column definition" in {
         emptyRecord.project(Set(ColumnDef[Any](""))).isFailure shouldBe true
-        emptyRecord.project(new RowRelation {
-          override def columns: Set[UntypedColumnDef] = Set(ColumnDef[Any](""))
-        }.columns).isFailure shouldBe true
       }
     }
 
@@ -76,9 +73,6 @@ class RecordTest extends WordSpec with Matchers {
       val col2 = ColumnDef[Int]("col2")
       val col3 = ColumnDef[Double]("col3")
       val record = Record(Set(col1, col2, col3)).build()
-      val R = new RowRelation {
-        override def columns: Set[UntypedColumnDef] = Set(col1, col2)
-      }
 
       "have a column set" in {
         record.columns.size shouldBe 3
@@ -104,7 +98,6 @@ class RecordTest extends WordSpec with Matchers {
         record.project(Set(col1)) should equal(Success(Record(Set(col1)).build()))
         record.project(Set(col2)) should equal(Success(Record(Set(col2)).build()))
         record.project(Set(col1, col3)) should equal(Success(Record(Set(col1, col3)).build()))
-        record.project(R.columns) should equal(Success(Record(Set(col1, col2)).build()))
       }
     }
 
@@ -120,9 +113,6 @@ class RecordTest extends WordSpec with Matchers {
         .withCellContent(col2)(val2)
         .withCellContent(col3)(val3)
         .build()
-      val R = new RowRelation {
-        override def columns: Set[UntypedColumnDef] = Set(col1, col2)
-      }
 
       "return the column's cell value" in {
         record.get(ColumnDef[Any]("")) shouldBe None
@@ -138,13 +128,6 @@ class RecordTest extends WordSpec with Matchers {
             r.get(col2) shouldBe None
             r.get(col3) shouldBe None
           case Failure(_) => fail("Projection by column sequence failed, but it should succeed")
-        }
-        record.project(R.columns) match {
-          case Success(r) =>
-            r.get(col1) shouldBe Some(val1)
-            r.get(col2) shouldBe Some(val2)
-            r.get(col3) shouldBe None
-          case Failure(_) => fail("Projection by Relation failed, but it should succeed")
         }
       }
     }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -80,9 +80,9 @@ class RecordTest extends WordSpec with Matchers {
         override def columns: Seq[UntypedColumnDef] = Seq(col1, col2)
       }
 
-      "have a column list" in {
+      "have a column set" in {
         record.columns.size shouldBe 3
-        record.columns shouldEqual Seq(col1, col2, col3)
+        record.columns shouldEqual Set(col1, col2, col3)
       }
 
       "return None, when accessing any column" in {

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/RecordTest.scala
@@ -60,14 +60,14 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to itself, when projected by an empty list" in {
-        emptyRecord.project(Set.empty: Set[UntypedColumnDef]) should equal(Success(emptyRecord))
+        emptyRecord.project(Set.empty) should equal(Success(emptyRecord))
       }
 
       "not allow projection, when projecting by any column definition" in {
-        emptyRecord.project(Set(ColumnDef[Any]("")): Set[UntypedColumnDef]).isFailure shouldBe true
+        emptyRecord.project(Set(ColumnDef[Any](""))).isFailure shouldBe true
         emptyRecord.project(new RowRelation {
           override def columns: Set[UntypedColumnDef] = Set(ColumnDef[Any](""))
-        }).isFailure shouldBe true
+        }.columns).isFailure shouldBe true
       }
     }
 
@@ -93,18 +93,18 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "project to empty record, when projected by an empty list" in {
-        record.project(Set.empty: Set[UntypedColumnDef]) should equal(Success(Record(Set.empty).build()))
+        record.project(Set.empty) should equal(Success(Record(Set.empty).build()))
       }
 
       "not allow projection, when projecting by any column definition" in {
-        record.project(Set(ColumnDef[Any]("")): Set[UntypedColumnDef]) should be.leftSideValue
+        record.project(Set(ColumnDef[Any](""))) should be.leftSideValue
       }
 
       "project to correct column subset, when projecting by contained columns" in {
-        record.project(Set(col1): Set[UntypedColumnDef]) should equal(Success(Record(Set(col1)).build()))
-        record.project(Set(col2): Set[UntypedColumnDef]) should equal(Success(Record(Set(col2)).build()))
-        record.project(Set(col1, col3): Set[UntypedColumnDef]) should equal(Success(Record(Set(col1, col3)).build()))
-        record.project(R) should equal(Success(Record(Set(col1, col2)).build()))
+        record.project(Set(col1)) should equal(Success(Record(Set(col1)).build()))
+        record.project(Set(col2)) should equal(Success(Record(Set(col2)).build()))
+        record.project(Set(col1, col3)) should equal(Success(Record(Set(col1, col3)).build()))
+        record.project(R.columns) should equal(Success(Record(Set(col1, col2)).build()))
       }
     }
 
@@ -132,14 +132,14 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "retain values of projected columns and drop others" in {
-        record.project(Set(col1): Set[UntypedColumnDef]) match {
+        record.project(Set(col1)) match {
           case Success(r) =>
             r.get(col1) shouldBe Some(val1)
             r.get(col2) shouldBe None
             r.get(col3) shouldBe None
           case Failure(_) => fail("Projection by column sequence failed, but it should succeed")
         }
-        record.project(R) match {
+        record.project(R.columns) match {
           case Success(r) =>
             r.get(col1) shouldBe Some(val1)
             r.get(col2) shouldBe Some(val2)

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -81,7 +81,7 @@ object TestApplication extends App {
 
   println()
   println("Projection of user relation:")
-  println(User.project(Set(User.colFirstname, User.colLastname): Set[UntypedColumnDef]).getOrElse(Set.empty))
+  println(User.project(Set[UntypedColumnDef](User.colFirstname, User.colLastname)).getOrElse(Set.empty))
 
 
   /**

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -20,7 +20,7 @@ object TestApplication extends App {
     val colLastname: ColumnDef[String] = ColumnDef("Lastname")
     val colAge: ColumnDef[Int] = ColumnDef("Age")
 
-    override val columns: Seq[UntypedColumnDef] = Seq(colFirstname, colLastname, colAge)
+    override val columns: Set[UntypedColumnDef] = Set(colFirstname, colLastname, colAge)
   }
 
   /**
@@ -31,7 +31,7 @@ object TestApplication extends App {
     val colName: ColumnDef[String] = ColumnDef("Name")
     val colDiscount: ColumnDef[Double] = ColumnDef("Discount")
 
-    override val columns: Seq[UntypedColumnDef] = Seq(colId, colName, colDiscount)
+    override val columns: Set[UntypedColumnDef] = Set(colId, colName, colDiscount)
   }
 
 
@@ -81,7 +81,7 @@ object TestApplication extends App {
 
   println()
   println("Projection of user relation:")
-  println(User.project(Seq(User.colFirstname, User.colLastname)).getOrElse(Seq.empty).pretty)
+  println(User.project(Set(User.colFirstname, User.colLastname): Set[UntypedColumnDef]).getOrElse(Set.empty))
 
 
   /**
@@ -98,8 +98,8 @@ object TestApplication extends App {
     )
     .build()
   println(record)
-  assert(record.project(Seq(User.colAge)) == Success(Record(Seq(User.colAge))(User.colAge ~> 45).build()))
-  assert(record.project(Seq(User.colAge, Customer.colDiscount)).isFailure)
+  assert(record.project(Set(User.colAge): Set[UntypedColumnDef]) == Success(Record(Set(User.colAge))(User.colAge ~> 45).build()))
+  assert(record.project(Set(User.colAge, Customer.colDiscount): Set[UntypedColumnDef]).isFailure)
 
   println(Customer.columns.mkString(", "))
   println()
@@ -147,5 +147,5 @@ object TestApplication extends App {
 
   println()
   println("Projection of customer relation:")
-  println(Customer.project(Seq(Customer.colName, Customer.colDiscount)).getOrElse(Seq.empty).pretty)
+  println(Customer.project(Set(Customer.colName, Customer.colDiscount): Set[UntypedColumnDef]).getOrElse(Set.empty))
 }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -81,7 +81,7 @@ object TestApplication extends App {
 
   println()
   println("Projection of user relation:")
-  println(User.project(Set[UntypedColumnDef](User.colFirstname, User.colLastname)).getOrElse(Set.empty))
+  println(User.project(Set(User.colFirstname, User.colLastname)).getOrElse(Set.empty))
 
 
   /**
@@ -98,8 +98,8 @@ object TestApplication extends App {
     )
     .build()
   println(record)
-  assert(record.project(Set(User.colAge): Set[UntypedColumnDef]) == Success(Record(Set(User.colAge))(User.colAge ~> 45).build()))
-  assert(record.project(Set(User.colAge, Customer.colDiscount): Set[UntypedColumnDef]).isFailure)
+  assert(record.project(Set(User.colAge)) == Success(Record(Set(User.colAge))(User.colAge ~> 45).build()))
+  assert(record.project(Set(User.colAge, Customer.colDiscount)).isFailure)
 
   println(Customer.columns.mkString(", "))
   println()
@@ -147,5 +147,5 @@ object TestApplication extends App {
 
   println()
   println("Projection of customer relation:")
-  println(Customer.project(Set(Customer.colName, Customer.colDiscount): Set[UntypedColumnDef]).getOrElse(Set.empty))
+  println(Customer.project(Set(Customer.colName, Customer.colDiscount)).getOrElse(Set.empty))
 }


### PR DESCRIPTION
Fixes #16 

## Proposed Changes

  - Use sets of `ColumnDef`'s instead of sequences since ordering should not matter w.r.t. columns or attribute fields
  - For both: `Record`'s and `Relation`'s