### PR TITLE
Add Try[Record] / Try[Seq[Record]] feedback to Relation.insert and .insertAll methods

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnRelation.scala
@@ -23,11 +23,12 @@ abstract class ColumnRelation extends Relation {
   }
 
   /** @inheritdoc */
-  override def insert(record: Record): Unit = {
+  override def insert(record: Record): Try[Record] = {
     columns.foreach(column => {
       val columnStore = data(column)
       columnStore.append(record(column).asInstanceOf[columnStore.valueType])
     })
+    Try(record)
   }
 
   /** @inheritdoc */

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -17,7 +17,7 @@ trait Relation {
     * Inserts a [[de.up.hpi.informationsystems.adbms.definition.Record]] into the relation
     * @param record to be inserted
     */
-  def insert(record: Record): Unit
+  def insert(record: Record): Try[Record]
 
   /**
     * Returns all records satisfying the provided condition.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -2,7 +2,7 @@ package de.up.hpi.informationsystems.adbms.definition
 
 import de.up.hpi.informationsystems.adbms.definition.Record.RecordBuilder
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 trait Relation {
 
@@ -55,9 +55,10 @@ trait Relation {
 
   /**
     * Inserts all Records into the relation.
+    * @note that this is not atomic
     * @param records to be inserted
     */
-  def insertAll(records: Seq[Record]): Unit = records.foreach(insert)
+  def insertAll(records: Seq[Record]): Try[Seq[Record]] = Success(records.map(insert).map(_.get))
 
   /**
     * Iff all columns of the other relation are a subset of this relation's columns,

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -53,12 +53,13 @@ trait Relation {
     */
   def newRecord: RecordBuilder = Record(columns)
 
-  // FIXME: insertAll is not atomic and insertions before a possible failure will stay in the relation
+
   /**
     * Inserts all Records into the relation.
     * @note that this is not atomic
     * @param records to be inserted
     */
+  // FIXME: insertAll is not atomic and insertions before a possible failure will stay in the relation
   def insertAll(records: Seq[Record]): Try[Seq[Record]] = Try(records.map(r => insert(r).get))
 
   /**

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -53,12 +53,13 @@ trait Relation {
     */
   def newRecord: RecordBuilder = Record(columns)
 
+  // FIXME: insertAll is not atomic and insertions before a possible failure will stay in the relation
   /**
     * Inserts all Records into the relation.
     * @note that this is not atomic
     * @param records to be inserted
     */
-  def insertAll(records: Seq[Record]): Try[Seq[Record]] = Success(records.map(insert).map(_.get))
+  def insertAll(records: Seq[Record]): Try[Seq[Record]] = Try(records.map(r => insert(r).get))
 
   /**
     * Iff all columns of the other relation are a subset of this relation's columns,

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -1,5 +1,4 @@
 package de.up.hpi.informationsystems.adbms.definition
-import de.up.hpi.informationsystems.adbms.definition
 
 import scala.util.Try
 
@@ -12,14 +11,13 @@ abstract class RowRelation extends Relation {
 
   @throws[IncompatibleColumnDefinitionException]
   private def internal_insert(record: Record): Record =
-  // check for correct column layout
-    record.columns.equals((this.columns)) match {
-      case true => {
-        data = data :+ record
-        record
-      }
-      case false => throw IncompatibleColumnDefinitionException(s"this records column layout does not match this " +
-        s"relations schema:\n${record.columns} (record)\n${this.columns} (relation)")
+    // check for correct column layout
+    if(record.columns == columns) {
+      data = data :+ record
+      record
+    } else {
+      throw IncompatibleColumnDefinitionException(s"this records column layout does not match this " +
+      s"relations schema:\n${record.columns} (record)\n${this.columns} (relation)")
     }
 
   /** @inheritdoc */

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -1,4 +1,6 @@
 package de.up.hpi.informationsystems.adbms.definition
+import de.up.hpi.informationsystems.adbms.definition
+
 import scala.util.Try
 
 abstract class RowRelation extends Relation {
@@ -6,7 +8,19 @@ abstract class RowRelation extends Relation {
   private var data: Seq[Record] = Seq.empty
 
   /** @inheritdoc */
-  override def insert(record: Record): Unit = data = data :+ record
+  override def insert(record: Record): Try[Record] = Try(internal_insert(record))
+
+  @throws[IncompatibleColumnDefinitionException]
+  private def internal_insert(record: Record): Record =
+  // check for correct column layout
+    record.columns.equals((this.columns)) match {
+      case true => {
+        data = data :+ record
+        record
+      }
+      case false => throw IncompatibleColumnDefinitionException(s"this records column layout does not match this " +
+        s"relations schema:\n${record.columns} (record)\n${this.columns} (relation)")
+    }
 
   /** @inheritdoc */
   override def where[T](f: (ColumnDef[T], T => Boolean)): Seq[Record] =

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -123,6 +123,20 @@ object TestApplication extends App {
       .withCellContent(Customer.colDiscount)(0.05)
       .build()
   )
+  Customer.insertAll(
+    Seq(
+      Record(Customer.columns)
+        .withCellContent(Customer.colId)(4)
+        .withCellContent(Customer.colName)("Tesla")
+        .withCellContent(Customer.colDiscount)(0.001)
+        .build(),
+      Record(Customer.columns)
+        .withCellContent(Customer.colId)(5)
+        .withCellContent(Customer.colName)("Hyundai")
+        .withCellContent(Customer.colDiscount)(0.01)
+        .build()
+    )
+  )
 
   println(Customer)
   println("where:")


### PR DESCRIPTION
Fixes #10 

## Proposed Changes

  - Check if the column layout of an inserted `Record` match that of the `Relation` to be inserted into
  - Return a `Try[Record]` from `Relation.insert` that contains the inserted record on success and a wrapped `IncompatibleColumnDefinitionException` on failure