### PR TITLE
Add .dactorSelection to Dactor companion object

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -61,7 +61,7 @@ abstract class Dactor(id: Int) extends Actor with ActorLogging {
     * @return ActorSelection of the lookup
     */
   protected def dactorSelection(clazz: Class[_ <: Dactor], id: Int): ActorSelection =
-    context.system.actorSelection(context.system / Dactor.nameOf(clazz, id))
+    Dactor.dactorSelection(context.system, clazz, id)
 
   override def preStart(): Unit = log.info(s"${this.getClass.getSimpleName}($id) started")
 

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -1,6 +1,6 @@
 package de.up.hpi.informationsystems.adbms
 
-import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSelection, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSelection, ActorSystem, Props}
 import de.up.hpi.informationsystems.adbms.definition.Relation
 
 object Dactor {
@@ -15,6 +15,16 @@ object Dactor {
     */
   def dactorOf(factory: ActorRefFactory, clazz: Class[_ <: Dactor], id: Int): ActorRef =
     factory.actorOf(Props(clazz, id), nameOf(clazz, id))
+
+  /**
+    * Looks up the path to a Dactor and returns the `ActorSelection`.
+    * @note lookup is global to the system, i.e. /user/$dactorName
+    * @param clazz class of the Dactor
+    * @param id id of the Dactor
+    * @return ActorSelection of the lookup
+    */
+  def dactorSelection(system: ActorSystem, clazz: Class[_ <: Dactor], id: Int): ActorSelection =
+    system.actorSelection(s"/user/${nameOf(clazz, id)}")
 
   /**
     * Constructs the name for a Dactor of type `clazz` and with id `id`.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -23,7 +23,7 @@ object Dactor {
     * @param id id of the Dactor
     * @return ActorSelection of the lookup
     */
-  def dactorSelection(system: ActorSystem, clazz: Class[_ <: Dactor], id: Int): ActorSelection =
+  def dactorSelection(system: ActorRefFactory, clazz: Class[_ <: Dactor], id: Int): ActorSelection =
     system.actorSelection(s"/user/${nameOf(clazz, id)}")
 
   /**

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -1,0 +1,55 @@
+package de.up.hpi.informationsystems.adbms.definition
+
+import akka.actor.{ActorNotFound, ActorRef, ActorSystem}
+import akka.testkit.TestKit
+import akka.util.Timeout
+import de.up.hpi.informationsystems.adbms.Dactor
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.FailureMessage
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+
+object DactorTest {
+  class TestDactor(id: Int) extends Dactor(id) {
+
+    override val relations: Map[String, Relation] = Map()
+
+    override def receive: Receive = {
+      case _ => {}
+    }
+  }
+}
+
+class DactorTest extends TestKit(ActorSystem("test-system"))
+  with WordSpecLike
+  with Matchers
+  with ScalaFutures {
+
+  "Dactor" can {
+
+    implicit val timeout: Timeout = 1.seconds
+
+    "using Dactor companion object" should {
+
+      "create new dactors of requested type using .dactorOf" in {
+        val testDactor = Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1)
+      }
+
+      "find existing dactors using .dactorSelection(...).resolve" in {
+        val future = Dactor.dactorSelection(system, classOf[DactorTest.TestDactor], 1).resolveOne()
+        ScalaFutures.whenReady(future) { ref =>
+          ref shouldBe a [ActorRef]
+        }
+      }
+
+      "fail to find dactors using .dactorSelection(...).resolve for non existing dactors" in {
+        val future = Dactor.dactorSelection(system, classOf[DactorTest.TestDactor], 2).resolveOne()
+        ScalaFutures.whenReady(future.failed) { e =>
+          e shouldBe a [ActorNotFound]
+        }
+      }
+    }
+  }
+
+}

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -1,17 +1,25 @@
 package de.up.hpi.informationsystems.adbms.definition
 
-import akka.actor.{ActorNotFound, ActorRef, ActorSystem}
+import akka.actor.{ActorNotFound, ActorRef, ActorSystem, InvalidActorNameException}
 import akka.testkit.TestKit
 import akka.util.Timeout
 import de.up.hpi.informationsystems.adbms.Dactor
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.FailureMessage
 import org.scalatest.{Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 
 object DactorTest {
   class TestDactor(id: Int) extends Dactor(id) {
+
+    override val relations: Map[String, Relation] = Map()
+
+    override def receive: Receive = {
+      case _ => {}
+    }
+  }
+
+  class TestDactor2(id: Int) extends Dactor(id) {
 
     override val relations: Map[String, Relation] = Map()
 
@@ -34,6 +42,14 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
 
       "create new dactors of requested type using .dactorOf" in {
         val testDactor = Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1)
+      }
+
+      "enforce unique id for the same classTag when using .dactorOf" in {
+        an [InvalidActorNameException] should be thrownBy (Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1))
+      }
+
+      "allow equal ids for different classes" in {
+        noException should be thrownBy (Dactor.dactorOf(system, classOf[DactorTest.TestDactor2], 1))
       }
 
       "find existing dactors using .dactorSelection(...).resolve" in {


### PR DESCRIPTION
## Proposed Changes

  - add `.dactorSelection` to `Dactor` companion object to use this as a *global actor registry*
  - lookups to certain `Dactor`'s then look like this:
```scala
val selection = Dactor.dactorSelection(actorSystem, classOf[MyDactorSubclass], id)

// you can use this selection to send messages
selection ! MyDactorSubclass.SomeMessage.Request()
```
  - being able to do the above is useful for testing and possibly during startup initialization

  - and you can get back an `ActorRef` if you absolutely have to like this:
```scala
val future = Dactor.dactorSelection(actorSystem, classOf[MyDactorSubclass], idFormerlyKnownAsName).resolveOne()

// you can do this to check if an actor actually exists
future onComplete {
  case Success(actor) => doSomethingWithActor(actor)
  case Failure(e: ActorNotFound) => handleError(e)
}
```

## Related

  - n/a
