### PR TITLE
Allow generic inserts for all `Dactor`s

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -87,7 +87,7 @@ abstract class Dactor(id: Int) extends Actor with ActorLogging {
     * @param records records to be inserted
     * @return either number of successfully inserted records or a `Throwable` describing the failure
     */
-  private def handleGenericInsert(relationName: String, records: Seq[Record]): Try[Int] =
-    relations(relationName).insertAll(records).map( _.count(_ => true) )
-
+  private def handleGenericInsert(relationName: String, records: Seq[Record]): Try[Int] = Try {
+    relations(relationName).insertAll(records).map(_.count(_ => true))
+  }.flatten
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -1,7 +1,11 @@
 package de.up.hpi.informationsystems.adbms
 
-import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSelection, ActorSystem, Props}
-import de.up.hpi.informationsystems.adbms.definition.Relation
+import akka.actor.Status.{Failure, Success}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSelection, Props}
+import de.up.hpi.informationsystems.adbms.definition.{MutableRelation, Record}
+import de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol
+
+import scala.util.Try
 
 object Dactor {
 
@@ -43,7 +47,7 @@ abstract class Dactor(id: Int) extends Actor with ActorLogging {
     * Returns all relations of this actor mapped with their name.
     * @return map of relation name and relation store
     */
-  protected val relations: Map[String, Relation]
+  protected def relations: Map[String, MutableRelation]
 
   /**
     * Creates a new Dactor of type `clazz` with id `id` in the same context as this Dactor and returns its ActorRef.
@@ -66,4 +70,24 @@ abstract class Dactor(id: Int) extends Actor with ActorLogging {
   override def preStart(): Unit = log.info(s"${this.getClass.getSimpleName}($id) started")
 
   override def postStop(): Unit = log.info(s"${this.getClass.getSimpleName}($id) stopped")
+
+  override def unhandled(message: Any): Unit = message match {
+    case DefaultMessagingProtocol.InsertIntoRelation(relationName, records) =>
+      handleGenericInsert(relationName, records) match {
+        case util.Success(_) => sender() ! Success
+        case util.Failure(e) => sender() ! Failure(e)
+      }
+    case _ => super.unhandled(message)
+  }
+
+
+  /**
+    * Inserts the specified records into the relation and returns the number of successfully inserted records.
+    * @param relationName name of the relation the records should be inserted to
+    * @param records records to be inserted
+    * @return either number of successfully inserted records or a `Throwable` describing the failure
+    */
+  private def handleGenericInsert(relationName: String, records: Seq[Record]): Try[Int] =
+    relations(relationName).insertAll(records).map( _.count(_ => true) )
+
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -47,7 +47,7 @@ abstract class Dactor(id: Int) extends Actor with ActorLogging {
     * Returns all relations of this actor mapped with their name.
     * @return map of relation name and relation store
     */
-  protected def relations: Map[String, MutableRelation]
+  protected val relations: Map[String, MutableRelation]
 
   /**
     * Creates a new Dactor of type `clazz` with id `id` in the same context as this Dactor and returns its ActorRef.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Record.scala
@@ -127,6 +127,8 @@ object Record {
     */
   def apply(columnDefs: Set[UntypedColumnDef]): RecordBuilder = new RecordBuilder(columnDefs, Map.empty)
 
+  val empty: Record = Record.empty
+
   /**
     * Builder for a [[de.up.hpi.informationsystems.adbms.definition.Record]].
     * Initiates the record builder with the column definition list the record should comply with.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
@@ -1,0 +1,9 @@
+package de.up.hpi.informationsystems.adbms.protocols
+
+import de.up.hpi.informationsystems.adbms.definition.Record
+
+object DefaultMessagingProtocol {
+
+  case class InsertIntoRelation(relation: String, records: Seq[Record])
+
+}

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
@@ -2,8 +2,18 @@ package de.up.hpi.informationsystems.adbms.protocols
 
 import de.up.hpi.informationsystems.adbms.definition.Record
 
+/**
+  * Provides default messages for the `adbms` framework.
+  */
 object DefaultMessagingProtocol {
 
+  /**
+    * Use this message to directly insert data into the relations of a `Dactor`.
+    * The `Dactor`s will return with a message from [[akka.actor.Status]].
+    * @note Use with caution! This message relies on internal details of `Dactor`s and could lead to tight coupling.
+    * @param relation name of the relation in regards
+    * @param records to be inserted records
+    */
   case class InsertIntoRelation(relation: String, records: Seq[Record])
 
 }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -12,7 +12,6 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.Try
 
 object DactorTest {
   class TestDactor(id: Int) extends Dactor(id) {
@@ -31,19 +30,25 @@ object DactorTest {
 
   object DactorWithRelation {
     def props(id: Int): Props = Props(new DactorWithRelation(id))
-    object TestRelation {
+
+    object TestRelationDef {
+      val name: String = "testrelation"
       val col1: ColumnDef[Int] = ColumnDef("col1")
       val col2: ColumnDef[String] = ColumnDef("col2")
       val columns: Set[UntypedColumnDef] = Set(col1, col2)
+
+      def rowRelation: MutableRelation = new RowRelation {
+        override val columns: Set[UntypedColumnDef] = TestRelationDef.columns
+      }
     }
+
   }
 
   class DactorWithRelation(id: Int) extends Dactor(id) {
-    val testRelation: MutableRelation = new RowRelation {
-      override val columns: Set[UntypedColumnDef] = DactorWithRelation.TestRelation.columns
-    }
+    import DactorWithRelation._
+    val testRelation: MutableRelation = TestRelationDef.rowRelation
 
-    override protected val relations: Map[String, MutableRelation] = Map("testrelation" -> testRelation)
+    override protected val relations: Map[String, MutableRelation] = Map(TestRelationDef.name -> testRelation)
 
     override def receive: Receive = Actor.emptyBehavior
   }
@@ -107,17 +112,17 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
     }
 
     "relations available" should {
-      import DactorTest.DactorWithRelation.TestRelation
+      import DactorTest.DactorWithRelation.TestRelationDef
       import de.up.hpi.informationsystems.adbms.definition.ColumnCellMapping._
 
       val probe = TestProbe()
       val dut = Dactor.dactorOf(system, classOf[DactorTest.DactorWithRelation], 1)
 
       "insert matching record successfully" in {
-        val insertMessage = DefaultMessagingProtocol.InsertIntoRelation("testrelation", Seq(
-          Record(TestRelation.columns)(
-            TestRelation.col1 ~> 1 &
-            TestRelation.col2 ~> "1"
+        val insertMessage = DefaultMessagingProtocol.InsertIntoRelation(TestRelationDef.name, Seq(
+          Record(TestRelationDef.columns)(
+            TestRelationDef.col1 ~> 1 &
+            TestRelationDef.col2 ~> "1"
           ).build()
         ))
         dut.tell(insertMessage, probe.ref)
@@ -125,18 +130,18 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
       }
 
       "insert multiple matching records successfully" in {
-        val insertMessage = DefaultMessagingProtocol.InsertIntoRelation("testrelation", Seq(
-          Record(TestRelation.columns)(
-            TestRelation.col1 ~> 1 &
-              TestRelation.col2 ~> "1"
+        val insertMessage = DefaultMessagingProtocol.InsertIntoRelation(TestRelationDef.name, Seq(
+          Record(TestRelationDef.columns)(
+            TestRelationDef.col1 ~> 1 &
+              TestRelationDef.col2 ~> "1"
           ).build(),
-          Record(TestRelation.columns)(
-            TestRelation.col1 ~> 2 &
-              TestRelation.col2 ~> "2"
+          Record(TestRelationDef.columns)(
+            TestRelationDef.col1 ~> 2 &
+              TestRelationDef.col2 ~> "2"
           ).build(),
-          Record(TestRelation.columns)(
-            TestRelation.col1 ~> 3 &
-              TestRelation.col2 ~> "3"
+          Record(TestRelationDef.columns)(
+            TestRelationDef.col1 ~> 3 &
+              TestRelationDef.col2 ~> "3"
           ).build()
         ))
         dut.tell(insertMessage, probe.ref)
@@ -144,9 +149,9 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
       }
 
       "fail inserting wrong records" in {
-        val insertMessage = DefaultMessagingProtocol.InsertIntoRelation("testrelation", Seq(
-          Record(Set(TestRelation.col1, ColumnDef[Float]("undefinedCol")))(
-            TestRelation.col1 ~> 1 &
+        val insertMessage = DefaultMessagingProtocol.InsertIntoRelation(TestRelationDef.name, Seq(
+          Record(Set(TestRelationDef.col1, ColumnDef[Float]("undefinedCol")))(
+            TestRelationDef.col1 ~> 1 &
             ColumnDef[Float]("undefinedCol") ~> 1.2f
           ).build()
         ))

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 object DactorTest {
   class TestDactor(id: Int) extends Dactor(id) {
 
-    override val relations: Map[String, Relation] = Map()
+    override val relations: Map[String, MutableRelation] = Map()
 
     override def receive: Receive = {
       case _ => {}
@@ -21,7 +21,7 @@ object DactorTest {
 
   class TestDactor2(id: Int) extends Dactor(id) {
 
-    override val relations: Map[String, Relation] = Map()
+    override val relations: Map[String, MutableRelation] = Map()
 
     override def receive: Receive = {
       case _ => {}

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -1,11 +1,14 @@
 package de.up.hpi.informationsystems.adbms.definition
 
-import akka.actor.{ActorNotFound, ActorRef, ActorSystem, InvalidActorNameException}
-import akka.testkit.TestKit
+import java.util.NoSuchElementException
+
+import akka.actor.{Actor, ActorNotFound, ActorRef, ActorSystem, InvalidActorNameException}
+import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import de.up.hpi.informationsystems.adbms.Dactor
+import de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 
@@ -14,42 +17,43 @@ object DactorTest {
 
     override val relations: Map[String, MutableRelation] = Map()
 
-    override def receive: Receive = {
-      case _ => {}
-    }
+    override def receive: Receive = Actor.emptyBehavior
   }
 
   class TestDactor2(id: Int) extends Dactor(id) {
 
     override val relations: Map[String, MutableRelation] = Map()
 
-    override def receive: Receive = {
-      case _ => {}
-    }
+    override def receive: Receive = Actor.emptyBehavior
   }
 }
 
 class DactorTest extends TestKit(ActorSystem("test-system"))
   with WordSpecLike
   with Matchers
-  with ScalaFutures {
+  with ScalaFutures
+  with BeforeAndAfterAll {
 
-  "Dactor" can {
+  override def afterAll: Unit = {
+    shutdown(system)
+  }
+
+  "Dactor" when {
 
     implicit val timeout: Timeout = 1.seconds
 
     "using Dactor companion object" should {
 
       "create new dactors of requested type using .dactorOf" in {
-        val testDactor = Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1)
+        noException should be thrownBy Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1)
       }
 
       "enforce unique id for the same classTag when using .dactorOf" in {
-        an [InvalidActorNameException] should be thrownBy (Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1))
+        an [InvalidActorNameException] should be thrownBy Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 1)
       }
 
       "allow equal ids for different classes" in {
-        noException should be thrownBy (Dactor.dactorOf(system, classOf[DactorTest.TestDactor2], 1))
+        noException should be thrownBy Dactor.dactorOf(system, classOf[DactorTest.TestDactor2], 1)
       }
 
       "find existing dactors using .dactorSelection(...).resolve" in {
@@ -65,6 +69,20 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
           e shouldBe a [ActorNotFound]
         }
       }
+    }
+
+     "no relations" should {
+
+       "reject insert messages with a Failure" in {
+         val probe = TestProbe()
+         val dut = Dactor.dactorOf(system, classOf[DactorTest.TestDactor], 99)
+
+         val msg = DefaultMessagingProtocol.InsertIntoRelation("someRelation", Seq(Record.empty))
+         dut.tell(msg, probe.ref)
+         val response = probe.expectMsgType[akka.actor.Status.Failure]
+         response.cause shouldBe a [NoSuchElementException]
+         response.cause.getMessage should startWith ("key not found")
+       }
     }
   }
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -6,8 +6,8 @@ import de.up.hpi.informationsystems.adbms.definition._
 import de.up.hpi.informationsystems.sampleapp.dactors.GroupManager
 
 import scala.concurrent.duration._
-import scala.util.Success
 import scala.language.postfixOps
+import scala.util.Success
 
 object TestApplication extends App {
   val system = ActorSystem("system")
@@ -72,7 +72,7 @@ class TestDactor(id: Int) extends Dactor(id) {
     override val columns: Set[UntypedColumnDef] = Set(colId, colName, colDiscount)
   }
 
-  override protected val relations: Map[String, Relation] = Map("User" -> User) ++ Map("Customer" -> Customer)
+  override protected val relations: Map[String, MutableRelation] = Map("User" -> User) ++ Map("Customer" -> Customer)
 
   override def receive: Receive = {
     case Test => test()
@@ -207,4 +207,5 @@ class TestDactor(id: Int) extends Dactor(id) {
     println(groupManager10)
     groupManager10 ! GroupManager.GetFixedDiscounts.Request(Seq(1,2,3))
   }
+
 }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -2,7 +2,9 @@ package de.up.hpi.informationsystems.sampleapp
 
 import akka.actor.{Actor, ActorSystem, Props}
 import de.up.hpi.informationsystems.adbms.Dactor
+import de.up.hpi.informationsystems.adbms.definition.ColumnCellMapping._
 import de.up.hpi.informationsystems.adbms.definition._
+import de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol
 import de.up.hpi.informationsystems.sampleapp.dactors.GroupManager
 
 import scala.concurrent.duration._
@@ -16,6 +18,16 @@ object TestApplication extends App {
     val tester = system.actorOf(TestDactor.props(1), "TestDactor-1")
     val groupManager10 = Dactor.dactorOf(system, classOf[GroupManager], 10)
 
+    val userCols: Set[UntypedColumnDef] = Set(
+      ColumnDef[String]("Firstname"),
+      ColumnDef[String]("Lastname"),
+      ColumnDef[Int]("Age")
+    )
+    tester.tell(DefaultMessagingProtocol.InsertIntoRelation("User", Seq(Record(userCols)(
+      ColumnDef[String]("Firstname") ~> "Somebody" &
+      ColumnDef[String]("Lastname") ~> "I used to know" &
+      ColumnDef[Int]("Age") ~> 12
+    ).build())), Actor.noSender)
     tester.tell(TestDactor.Test, Actor.noSender)
 
     // shutdown system
@@ -77,7 +89,6 @@ class TestDactor(id: Int) extends Dactor(id) {
   override def receive: Receive = {
     case Test => test()
     case Terminate() => context.system.terminate()
-    case e => println(s"Received Message:\n$e")
   }
 
   def test(): Unit = {
@@ -139,7 +150,6 @@ class TestDactor(id: Int) extends Dactor(id) {
 
     println()
     println()
-    import de.up.hpi.informationsystems.adbms.definition.ColumnCellMapping._
     val record = User.newRecord(
       User.colFirstname ~> "Firstname" &
       User.colLastname ~> "Lastname" &

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -50,7 +50,7 @@ class Cart(id: Int) extends Dactor(id) {
       Set(sectionId, sessionId, inventoryId, quantity, fixedDiscount, minPrice, price)
   }
 
-  override protected val relations: Map[String, Relation] =
+  override protected val relations: Map[String, MutableRelation] =
     Map("cart_info" -> CartInfo) ++ Map("cart_purchases" -> CartPurchases)
 
   override def receive: Receive = {

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -64,7 +64,7 @@ class Customer(id: Int) extends Dactor(id) {
     override val columns: Set[UntypedColumnDef] = Set(encryptedPassword)
   }
 
-  override protected val relations: Map[String, Relation] =
+  override protected val relations: Map[String, MutableRelation] =
     Map("customer_info" -> CustomerInfo) ++ Map("store_visits" -> StoreVisits) ++ Map("passwd" -> Password)
 
   override def receive: Receive = {

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
@@ -30,7 +30,7 @@ class GroupManager(id: Int) extends Dactor(id) {
     override val columns: Set[UntypedColumnDef] = Set(id, fixedDisc)
   }
 
-  override protected val relations: Map[String, Relation] = Map("discounts" -> Discounts)
+  override protected val relations: Map[String, MutableRelation] = Map("discounts" -> Discounts)
 
   override def receive: Receive = {
     case GetFixedDiscounts.Request(ids) =>

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
@@ -55,7 +55,7 @@ class StoreSection(id: Int) extends Dactor(id) {
     override val columns: Set[UntypedColumnDef] = Set(inventoryId, time, quantity, cartId)
   }
 
-  override protected val relations: Map[String, Relation] =
+  override protected val relations: Map[String, MutableRelation] =
     Map("inventory" -> Inventory) ++
     Map("purchase_history" -> PurchaseHistory)
 


### PR DESCRIPTION
<!-- Optional: -->
Fixes #51

## Proposed Changes

  - generic function for all `Dactor`s allowing inserts
    - insert is handled by `Dactor` class, no additional implementation needed for app. dev.
    - **only works if no wildcard match is supplied to `receive`-function**
  - generic `InsertIntoRelation(relationName: String, records: Seq[Record])` message

still needs some more tests