### PR TITLE
Proposal: New creation of relations in dactors

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -58,13 +58,13 @@ abstract class Dactor(id: Int) extends Actor with ActorLogging {
     * Returns a map of relation definition and corresponding relational store.
     * @return map of relation definition and corresponding relational store
     */
-  protected val relationFromDef: Map[RelationDef, MutableRelation]
+  protected val relations: Map[RelationDef, MutableRelation]
 
   /**
     * Returns all relations of this actor mapped with their name.
     * @return map of relation name and relational store
     */
-  protected val relationFromName: Map[String, MutableRelation] = relationFromDef.map(mapping => {
+  protected def relationFromName: Map[String, MutableRelation] = relations.map(mapping => {
     mapping._1.name -> mapping._2
   })
 

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -16,14 +16,14 @@ import scala.language.postfixOps
 object DactorTest {
   class TestDactor(id: Int) extends Dactor(id) {
 
-    override val relations: Map[String, MutableRelation] = Map()
+    override val relationFromDef: Map[RelationDef, MutableRelation] = Map.empty
 
     override def receive: Receive = Actor.emptyBehavior
   }
 
   class TestDactor2(id: Int) extends Dactor(id) {
 
-    override val relations: Map[String, MutableRelation] = Map()
+    override val relationFromDef: Map[RelationDef, MutableRelation] = Map.empty
 
     override def receive: Receive = Actor.emptyBehavior
   }
@@ -43,9 +43,9 @@ object DactorTest {
 
   class DactorWithRelation(id: Int) extends Dactor(id) {
     import DactorWithRelation._
-    val testRelation: MutableRelation = RowRelation(TestRelation)
 
-    override protected val relations: Map[String, MutableRelation] = Map(TestRelation.name -> testRelation)
+    override protected val relationFromDef: Map[RelationDef, MutableRelation] =
+      Dactor.createAsRowRelations(Seq(TestRelation))
 
     override def receive: Receive = Actor.emptyBehavior
   }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/DactorTest.scala
@@ -16,14 +16,14 @@ import scala.language.postfixOps
 object DactorTest {
   class TestDactor(id: Int) extends Dactor(id) {
 
-    override val relationFromDef: Map[RelationDef, MutableRelation] = Map.empty
+    override val relations: Map[RelationDef, MutableRelation] = Map.empty
 
     override def receive: Receive = Actor.emptyBehavior
   }
 
   class TestDactor2(id: Int) extends Dactor(id) {
 
-    override val relationFromDef: Map[RelationDef, MutableRelation] = Map.empty
+    override val relations: Map[RelationDef, MutableRelation] = Map.empty
 
     override def receive: Receive = Actor.emptyBehavior
   }
@@ -44,7 +44,7 @@ object DactorTest {
   class DactorWithRelation(id: Int) extends Dactor(id) {
     import DactorWithRelation._
 
-    override protected val relationFromDef: Map[RelationDef, MutableRelation] =
+    override protected val relations: Map[RelationDef, MutableRelation] =
       Dactor.createAsRowRelations(Seq(TestRelation))
 
     override def receive: Receive = Actor.emptyBehavior

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -52,11 +52,8 @@ object Cart {
 class Cart(id: Int) extends Dactor(id) {
   import Cart._
 
-  val cartInfo = RowRelation(CartInfo)
-  val cartPurchases = RowRelation(CartPurchases)
-
-  override protected val relations: Map[String, MutableRelation] =
-    Map(CartInfo.name -> cartInfo) ++ Map(CartPurchases.name -> cartPurchases)
+  override protected val relations: Map[RelationDef, MutableRelation] =
+    Dactor.createAsRowRelations(Seq(CartInfo, CartPurchases))
 
   override def receive: Receive = {
     case AddItems.Request(_, _) => sender() ! AddItems.Failure(new NotImplementedError)

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -186,7 +186,7 @@ class Cart(id: Int) extends Dactor(id) {
   override def receive: Receive = {
     case AddItems.Request(orders, customerId) => AddItemsHelper(context.system, self, timeout).help(orders, customerId, sender())
 
-    case AddItemsHelper.Success(records, replyTo) => cartPurchases.insertAll(records) match {
+    case AddItemsHelper.Success(records, replyTo) => relations(CartPurchases).insertAll(records) match {
       case Success(_) => replyTo ! AddItems.Success(currentSessionId)
       case Failure(e) => replyTo ! AddItems.Failure(e)
     }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -68,13 +68,8 @@ object Customer {
 class Customer(id: Int) extends Dactor(id) {
   import Customer._
 
-  val customerInfo = RowRelation(CustomerInfo)
-  val storeVisits = RowRelation(StoreVisits)
-  val password = RowRelation(Password)
-
-  override protected val relations: Map[String, MutableRelation] = Map(CustomerInfo.name -> customerInfo) ++
-    Map(StoreVisits.name -> storeVisits) ++
-    Map(Password.name -> password)
+  override protected val relations: Map[RelationDef, MutableRelation] =
+    Dactor.createAsRowRelations(Seq(CustomerInfo, StoreVisits, Password))
 
   override def receive: Receive = {
     case GetCustomerInfo.Request() =>
@@ -96,10 +91,10 @@ class Customer(id: Int) extends Dactor(id) {
       }
   }
 
-  def getCustomerInfo(): Try[Seq[Record]] = customerInfo.records
+  def getCustomerInfo(): Try[Seq[Record]] = relations(CustomerInfo).records
 
   def addStoreVisit(storeId: Int, time: LocalDateTime, amount: Double, fixedDiscount: Double, varDiscount: Double): Try[Record] =
-    storeVisits.insert(StoreVisits.newRecord(
+    relations(StoreVisits).insert(StoreVisits.newRecord(
       StoreVisits.storeId ~> storeId
         & StoreVisits.timestamp ~> time
         & StoreVisits.amount ~> amount
@@ -108,7 +103,7 @@ class Customer(id: Int) extends Dactor(id) {
     ).build())
 
   def authenticate(passwordHash: String): Boolean = {
-    val res = password.where[String](Password.encryptedPassword -> {
+    val res = relations(Password).where[String](Password.encryptedPassword -> {
       _.equals(passwordHash)
     }).records
     res.isFailure || res.get.length == 1

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -111,7 +111,7 @@ class Customer(id: Int) extends Dactor(id) {
     if (rowCount > 1) {
       throw InconsistentStateException(s"this relation was expected to contain at maximum 1 row, but contained $rowCount")
     }
-    Try(customerInfo.records.get.head)
+    Try(relations(CustomerInfo).records.get.head)
   }
 
   def getCustomerGroupId: Try[Int] = {

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
@@ -31,9 +31,8 @@ object GroupManager {
 class GroupManager(id: Int) extends Dactor(id) {
   import GroupManager._
 
-  val discounts = RowRelation(Discounts)
-
-  override protected val relations: Map[String, MutableRelation] = Map(Discounts.name -> discounts)
+  override protected val relations: Map[RelationDef, MutableRelation] =
+    Dactor.createAsRowRelations(Seq(Discounts))
 
   override def receive: Receive = {
     case GetFixedDiscounts.Request(ids) =>
@@ -44,7 +43,7 @@ class GroupManager(id: Int) extends Dactor(id) {
   }
 
   def getFixedDiscounts(ids: Seq[Int]): Try[Seq[Record]] =
-    discounts
+    relations(Discounts)
       .where(Discounts.id -> { id: Int => ids.contains(id) })
       .records
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
@@ -56,12 +56,8 @@ object StoreSection {
 class StoreSection(id: Int) extends Dactor(id) {
   import StoreSection._
 
-  val inventory = RowRelation(Inventory)
-  val purchaseHistory = RowRelation(PurchaseHistory)
-
-  override protected val relations: Map[String, MutableRelation] =
-    Map(Inventory.name -> inventory) ++
-    Map(PurchaseHistory.name -> purchaseHistory)
+  override protected val relations: Map[RelationDef, MutableRelation] =
+    Dactor.createAsRowRelations(Seq(Inventory, PurchaseHistory))
 
   override def receive: Receive = {
     case GetPrice.Request(inventoryIds) =>
@@ -76,7 +72,7 @@ class StoreSection(id: Int) extends Dactor(id) {
 
   def getPrice(inventoryIds: Seq[Int]): Try[Seq[Record]] = {
     val resultSchema = Set(Inventory.price, Inventory.minPrice)
-    inventory
+    relations(Inventory)
       .project(resultSchema)
       .where[Int](Inventory.inventoryId -> { id => inventoryIds.contains(id) })
       .records


### PR DESCRIPTION
## Proposed Changes

  - more elegant way of defining relations in `Dactor`s:

```scala
object Cart {
  object CartInfo extends RelationDef {
    val cartId: ColumnDef[Int] = ColumnDef("c_id")
    val storeId: ColumnDef[Int] = ColumnDef("store_id")
    val sessionId: ColumnDef[Int] = ColumnDef("session_id")

    override val columns: Set[UntypedColumnDef] = Set(cartId, storeId, sessionId)
    override val name: String = "cart_info"
  }
}

class Cart(id: Int) extends Dactor(id) {
  import Cart._

  override protected val relations: Map[RelationDef, MutableRelation] =
    Dactor.createAsRowRelations(Seq(CartInfo, CartPurchases))

  override def receive: Receive = {
    val result = relations(CartInfo).insert(CartInfo.newRecord().build())
  }

}
```

## Related

  - #58 *(merge first!)*
