### PR TITLE
Apply a function on a column of a relation

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/FutureRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/FutureRelation.scala
@@ -12,16 +12,12 @@ import scala.util.Try
 
 trait FutureRelation extends Relation with Immutable with Awaitable[Try[Seq[Record]]] {
 
-  /** @inheritdoc */
   def pipeAsMessageTo[B](mapping: Relation => B, receiver: ActorRef): Unit
 
-  /** @inheritdoc */
   def future: Future[Relation]
 
-  /** @inheritdoc */
   def transform(f: Relation => Relation): FutureRelation
 
-  /** @inheritdoc */
   def flatTransform(f: Relation => FutureRelation): FutureRelation
 
   /** @inheritdoc */
@@ -50,6 +46,9 @@ trait FutureRelation extends Relation with Immutable with Awaitable[Try[Seq[Reco
 
   /** @inheritdoc */
   override def union(other: Relation): FutureRelation
+
+  /** @inheritdoc */
+  override def applyOn[T](col: ColumnDef[T], f: T => T): FutureRelation
 }
 
 object FutureRelation {
@@ -117,6 +116,10 @@ object FutureRelation {
     /** @inheritdoc*/
     override def union(other: Relation): FutureRelation =
       futureCheckedBinaryTransformation(other, (rel1, rel2) => rel1.union(rel2))
+
+    /** @inheritdoc */
+    override def applyOn[T](col: ColumnDef[T], f: T => T): FutureRelation =
+      FutureRelation(data.map(_.applyOn(col, f)))
 
     /**
       * Blocks until all Futures are complete

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/Relation.scala
@@ -111,6 +111,15 @@ trait Relation {
   def union(other: Relation): Relation
 
   /**
+    * Applies `f` on all values of the column `col`.
+    * @param col column, whos values should be changed
+    * @param f transformation function
+    * @tparam T type of the column
+    * @return a new relation with the changed column values
+    */
+  def applyOn[T](col: ColumnDef[T], f: T => T): Relation
+
+  /**
     * Converts this Relation to a sequence of Records.
     * @note Depending on the underlying Relation, this operation can be very costly!
     * @return a sequence of Records if all

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/RowRelation.scala
@@ -102,6 +102,10 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
     Relation(records).union(other)
 
   /** @inheritdoc */
+  override def applyOn[T](col: ColumnDef[T], f: T => T): Relation =
+    Relation(records).applyOn(col, f)
+
+  /** @inheritdoc */
   override def records: Try[Seq[Record]] = Try(data)
 
   /** @inheritdoc */

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/TransientRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/TransientRelation.scala
@@ -118,6 +118,20 @@ private[definition] final class TransientRelation(data: Try[Seq[Record]]) extend
         }
       })
 
+  /** @inheritdoc*/
+  override def applyOn[T](col: ColumnDef[T], f: T => T): Relation =
+    if(isFailure || !Set(col).subsetOf(columns))
+      this
+    else
+      Relation(Try{
+        internal_data.map( record => record.get(col) match {
+          case Some(value) =>
+            val newValue = f(value)
+            record.updated(col, newValue)
+          case None => record
+        })
+      })
+
   /** @inheritdoc */
   override def union(other: Relation): Relation =
     if(isFailure)

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/TransientRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/TransientRelationTest.scala
@@ -98,6 +98,12 @@ class TransientRelationTest extends WordSpec with Matchers {
           .records
           .isFailure shouldBe true
       }
+
+      "return an empty result set for any applyOn function" in {
+        emptyRelation
+          .applyOn(colFirstname, (name: String) => "something bad!")
+          .records shouldEqual Success(Seq.empty)
+      }
     }
 
     "full" should {
@@ -142,6 +148,15 @@ class TransientRelationTest extends WordSpec with Matchers {
           .project(columns + ColumnDef[Int]("bad-col"))
           .records
           .isFailure shouldBe true
+      }
+
+      "return an appropriate result set for an applyOn function" in {
+        fullRelation
+          .applyOn(colFirstname, (name: String) => name + " test")
+          .records shouldEqual Success(Seq(
+            record1.updated(colFirstname, "Test test"),
+            record2.updated(colFirstname, "Max test")
+          ))
       }
 
       /* Joins */
@@ -465,6 +480,17 @@ class TransientRelationTest extends WordSpec with Matchers {
             colAge.untyped -> {id: Any => id.asInstanceOf[Int] <= 2},
             colFirstname.untyped -> {field: Any => field.asInstanceOf[String].contains("esty")}
           )).records shouldEqual Success(Seq.empty)
+      }
+
+      "return an appropriate result set for an applyOn function" in {
+        incompleteRelation
+          .applyOn(colFirstname, (name: String) => name + " test")
+          .records shouldEqual Success(Seq(
+          record1.updated(colFirstname, "Test test"),
+          record2.updated(colFirstname, "Max test"),
+          record3,  // missing
+          record4   // null
+        ))
       }
     }
   }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/TestApplication.scala
@@ -212,6 +212,8 @@ class TestDactor(id: Int) extends Dactor(id) {
     println()
     println("Projection of customer relation:")
     println(relations(Customer).project(Set(Customer.colName, Customer.colDiscount)).records.getOrElse(Seq.empty).pretty)
+    println("\nApplyOn test")
+    println(relations(Customer).applyOn(Customer.colName, (name: String) => name + " test" ))
 
     /**
       * Testing communicating with another actor


### PR DESCRIPTION
## Proposed Changes

  -  `applyOn(col, func)` implemented on `Relation`
  - usage:

```scala
val newRelation = relation.applyOn(stringCol, (s: String) => s + " test")
```

**Note:**

I implemented it and after that noticed that I do not need it. Don't wanted to throw it away anyway.