### PR TITLE
Change RequestResponseProtocol.Success to wrap around Relation instead of Seq[Record]

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -100,7 +100,7 @@ object Dactor {
             case s: RequestResponseProtocol.Success => scala.util.Success(s.result)
             case f: RequestResponseProtocol.Failure => scala.util.Failure(f.e)
           }
-          .map(obj => Relation(obj))
+          .map(_.get)
       })
 
     FutureRelation(Future.sequence(results).map(_.reduce( (rel1, rel2) => rel1.union(rel2))))

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
@@ -1,6 +1,6 @@
 package de.up.hpi.informationsystems.adbms.protocols
 
-import de.up.hpi.informationsystems.adbms.record.Record
+import de.up.hpi.informationsystems.adbms.relation.Relation
 
 object RequestResponseProtocol {
 
@@ -18,7 +18,7 @@ object RequestResponseProtocol {
     * @see[[de.up.hpi.informationsystems.adbms.protocols.RequestResponseProtocol.Response]]
     */
   trait Success extends Response {
-    def result: Seq[Record]
+    def result: Relation
   }
 
   /** A failure Response that is used to inform about some failure during answering to a Request.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
@@ -59,6 +59,11 @@ trait MutableRelation extends Relation {
   // FIXME: insertAll is not atomic and insertions before a possible failure will stay in the relation
   def insertAll(records: Seq[Record]): Try[Seq[Record]] = Try(records.map(r => insert(r).get))
 
+  /**
+    * Returns an immutable copy of this relation.
+    * @return an [[de.up.hpi.informationsystems.adbms.relation.TransientRelation]] as an immutable copy of this relation
+    */
+  def immutable: Relation
 
   // helper
   /**

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/Relation.scala
@@ -13,7 +13,7 @@ object Relation {
 
   def apply(data: Seq[Record]): Relation = new TransientRelation(Try(data))
 
-  def empty = new TransientRelation(Try(Seq.empty))
+  val empty = new TransientRelation(Try(Seq.empty))
 }
 
 trait Relation {

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/Relation.scala
@@ -12,6 +12,8 @@ object Relation {
   def apply(dataTry: Try[Seq[Record]]): Relation = new TransientRelation(dataTry)
 
   def apply(data: Seq[Record]): Relation = new TransientRelation(Try(data))
+
+  def empty = new TransientRelation(Try(Seq.empty))
 }
 
 trait Relation {

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RowRelation.scala
@@ -113,6 +113,9 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
   /** @inheritdoc */
   override def toString: String = s"${this.getClass.getSimpleName}:\n" + Util.prettyTable(columns, data)
 
+  /** @inheritdoc*/
+  override def immutable: Relation = Relation(data)
+
   @throws[IncompatibleColumnDefinitionException]
   private def exceptionWhenNotSubset(incomingColumns: Iterable[UntypedColumnDef]): Unit =
     if (!(incomingColumns.toSet subsetOf columns)) {

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelation.scala
@@ -18,6 +18,14 @@ private[relation] final class TransientRelation(data: Try[Seq[Record]]) extends 
     else
       data.get.head.columns
 
+  /** @inheritdoc*/
+  override def equals(obj: scala.Any): Boolean =
+    obj.isInstanceOf[TransientRelation] &&
+      (hashCode() == obj.asInstanceOf[TransientRelation].hashCode())
+
+  override def hashCode(): Int =
+    internal_data.hashCode() + isFailure.hashCode() + columns.hashCode()
+
   /** @inheritdoc */
   override def where[T](f: (ColumnDef[T], T => Boolean)): Relation =
     if(isFailure)

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelationTest.scala
@@ -82,6 +82,10 @@ class TransientRelationTest extends WordSpec with Matchers {
     "empty" should {
       val emptyRelation = Relation(Seq.empty)
 
+      "equal another empty relation with the same column definition" in {
+        emptyRelation shouldEqual Relation(Seq.empty)
+      }
+
       "return an empty result set for any where query" in {
         emptyRelation
           .where(colFirstname, (_: String) => true)
@@ -111,6 +115,14 @@ class TransientRelationTest extends WordSpec with Matchers {
 
     "full" should {
       val fullRelation = Relation(Seq(record1, record2))
+
+      "equal another relation with the same columns and contents" in {
+        fullRelation shouldEqual Relation(Seq(record1, record2))
+      }
+
+      "not equal another relation with the same columns but different contents" in {
+        fullRelation should not equal Relation(Seq(record1))
+      }
 
       "return the appropriate result set for a where query including the empty result set" in {
         fullRelation

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -28,13 +28,13 @@ object Cart {
 
     // orders: item_id, i_quantity
     case class Request(orders: Seq[Order], customerId: Int) extends RequestResponseProtocol.Request
-    case class Success(result: Seq[Record]) extends RequestResponseProtocol.Success
+    case class Success(result: Relation) extends RequestResponseProtocol.Success
     case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
   }
 
   object Checkout {
     case class Request(sessionId: Int) extends RequestResponseProtocol.Request
-    case class Success(result: Seq[Record]) extends RequestResponseProtocol.Success
+    case class Success(result: Relation) extends RequestResponseProtocol.Success
     case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
   }
 
@@ -203,7 +203,7 @@ object Cart {
       case CartHelper.HandledAddItems(records, newSessionId, replyTo) =>
         relations(CartPurchases).insertAll(records) match {
           case Success(_) => {
-            val result = Seq(Record(Set(CartInfo.sessionId))(CartInfo.sessionId ~> newSessionId).build())
+            val result: Relation = Relation(Seq(Record(Set(CartInfo.sessionId))(CartInfo.sessionId ~> newSessionId).build()))
             replyTo ! AddItems.Success(result)
           }
           case Failure(e) => replyTo ! AddItems.Failure(e)
@@ -236,7 +236,7 @@ object Cart {
       }
 
       case CartHelper.HandledCheckout(amount, replyTo) =>
-        replyTo ! Checkout.Success(Seq(Record(Set(ColumnDef[Double]("amount")))(ColumnDef[Double]("amount") ~> amount).build()))
+        replyTo ! Checkout.Success(Relation(Seq(Record(Set(ColumnDef[Double]("amount")))(ColumnDef[Double]("amount") ~> amount).build())))
     }
   }
 }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -97,7 +97,7 @@ object Customer {
 
       case AddStoreVisit.Request(storeId: Int, time: ZonedDateTime, amount: Double, fixedDiscount: Double, varDiscount: Double) =>
         addStoreVisit(storeId, time, amount, fixedDiscount, varDiscount) match {
-          case Success(_) => sender() ! AddStoreVisit.Success(Relation(Seq.empty))
+          case Success(_) => sender() ! AddStoreVisit.Success(Relation.empty)
           case Failure(e) => sender() ! AddStoreVisit.Failure(e)
         }
 
@@ -109,21 +109,21 @@ object Customer {
         }
     }
 
-    def getCustomerInfo: Try[Relation] = {
+    def getCustomerInfo: Try[Relation] = Try{
       val rowCount = relations(CustomerInfo).records.get.size
       if (rowCount > 1) {
         throw InconsistentStateException(s"this relation was expected to contain at maximum 1 row, but contained $rowCount")
       }
-      Try(Relation(relations(CustomerInfo).records.get))
+      Relation(relations(CustomerInfo).records.get)
     }
 
-    def getCustomerGroupId: Try[Relation] = {
+    def getCustomerGroupId: Try[Relation] = Try{
       val rowCount = relations(CustomerInfo).records.get.size
       if (rowCount > 1) {
         throw InconsistentStateException(s"this relation was expected to contain at maximum 1 row, but contained $rowCount")
       }
-      Try(relations(CustomerInfo)
-        .project(Set(CustomerInfo.custGroupId)))
+      relations(CustomerInfo)
+        .project(Set(CustomerInfo.custGroupId))
     }
 
     def addStoreVisit(storeId: Int, time: ZonedDateTime, amount: Double, fixedDiscount: Double, varDiscount: Double): Try[Record] =

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -103,7 +103,7 @@ object Customer {
 
       case Authenticate.Request(passwordHash) =>
         if (authenticate(passwordHash)) {
-          sender() ! Authenticate.Success(Relation(Seq.empty))
+          sender() ! Authenticate.Success(Relation.empty)
         } else {
           sender() ! Authenticate.Failure(AuthenticationFailedException("failed to authenticate using password"))
         }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -114,7 +114,7 @@ object Customer {
       if (rowCount > 1) {
         throw InconsistentStateException(s"this relation was expected to contain at maximum 1 row, but contained $rowCount")
       }
-      Relation(relations(CustomerInfo).records.get)
+      relations(CustomerInfo).immutable
     }
 
     def getCustomerGroupId: Try[Relation] = Try{

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
@@ -40,16 +40,15 @@ object GroupManager {
 
     override def receive: Receive = {
       case GetFixedDiscounts.Request(ids) =>
-        getFixedDiscounts(ids) match {
-          case Success(result) => sender() ! GetFixedDiscounts.Success(result)
+        getFixedDiscounts(ids).records match {
+          case Success(records) => sender() ! GetFixedDiscounts.Success(Relation(records))
           case Failure(e) => sender() ! GetFixedDiscounts.Failure(e)
         }
     }
 
-    def getFixedDiscounts(ids: Seq[Int]): Try[Relation] = Try(
+    def getFixedDiscounts(ids: Seq[Int]): Relation =
       relations(Discounts)
         .where(Discounts.id -> { id: Int => ids.contains(id) })
-      )
   }
 }
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
@@ -5,7 +5,7 @@ import de.up.hpi.informationsystems.adbms.Dactor
 import de.up.hpi.informationsystems.adbms.definition._
 import de.up.hpi.informationsystems.adbms.protocols.{DefaultMessageHandling, RequestResponseProtocol}
 import de.up.hpi.informationsystems.adbms.record.Record
-import de.up.hpi.informationsystems.adbms.relation.MutableRelation
+import de.up.hpi.informationsystems.adbms.relation.{MutableRelation, Relation}
 import de.up.hpi.informationsystems.sampleapp.DataInitializer
 
 import scala.util.{Failure, Success, Try}
@@ -20,7 +20,7 @@ object GroupManager {
 
     case class Request(ids: Seq[Int]) extends RequestResponseProtocol.Request
     // results: i_id, fixed_disc
-    case class Success(result: Seq[Record]) extends RequestResponseProtocol.Success
+    case class Success(result: Relation) extends RequestResponseProtocol.Success
     case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
 
   }
@@ -46,11 +46,10 @@ object GroupManager {
         }
     }
 
-    def getFixedDiscounts(ids: Seq[Int]): Try[Seq[Record]] =
+    def getFixedDiscounts(ids: Seq[Int]): Try[Relation] = Try(
       relations(Discounts)
         .where(Discounts.id -> { id: Int => ids.contains(id) })
-        .records
-
+      )
   }
 }
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
@@ -69,8 +69,8 @@ object StoreSection {
 
     override def receive: Receive = {
       case GetPrice.Request(inventoryIds) =>
-        getPrice(inventoryIds) match {
-          case Success(result) => sender() ! GetPrice.Success(result)
+        getPrice(inventoryIds).records match {
+          case Success(result) => sender() ! GetPrice.Success(Relation(result))
           case Failure(e) => sender() ! GetPrice.Failure(e)
         }
 
@@ -81,11 +81,11 @@ object StoreSection {
         }
     }
 
-    def getPrice(inventoryIds: Seq[Int]): Try[Relation] = {
+    def getPrice(inventoryIds: Seq[Int]): Relation = {
       val resultSchema: Set[UntypedColumnDef] = Set(Inventory.inventoryId, Inventory.price, Inventory.minPrice)
-      Try(relations(Inventory)
+      relations(Inventory)
         .project(resultSchema)
-        .where[Int](Inventory.inventoryId -> { id => inventoryIds.contains(id) }))
+        .where[Int](Inventory.inventoryId -> { id => inventoryIds.contains(id) })
     }
 
     /**

--- a/sampleapp/src/test/scala/de/up/hpi/informationsystems/sampleapp/test/dactors/StoreSectionTest.scala
+++ b/sampleapp/src/test/scala/de/up/hpi/informationsystems/sampleapp/test/dactors/StoreSectionTest.scala
@@ -68,7 +68,7 @@ class StoreSectionTest(_system: ActorSystem)
       "return empty when calling GetPrice for non-existent inventoryIds" in {
         val probe = new TestProbe(system)
         storeSection1.tell(StoreSection.GetPrice.Request(Seq(10, 11)), probe.ref)
-        probe.expectMsg(StoreSection.GetPrice.Success(Relation(Seq.empty)))
+        probe.expectMsg(StoreSection.GetPrice.Success(Relation.empty))
       }
 
       // TODO Failure cases

--- a/sampleapp/src/test/scala/de/up/hpi/informationsystems/sampleapp/test/dactors/StoreSectionTest.scala
+++ b/sampleapp/src/test/scala/de/up/hpi/informationsystems/sampleapp/test/dactors/StoreSectionTest.scala
@@ -51,24 +51,24 @@ class StoreSectionTest(_system: ActorSystem)
       "accept GetPrice messages successfully" in {
         val probe = new TestProbe(system)
         storeSection1.tell(StoreSection.GetPrice.Request(Seq(100, 101)), probe.ref)
-        probe.expectMsg(StoreSection.GetPrice.Success(Seq(
-          Record(Set(Inventory.inventoryId, Inventory.price, Inventory.minPrice))(
-            Inventory.inventoryId ~> 100 &
-            Inventory.price ~> 9.99 &
-            Inventory.minPrice ~> 6.39
-          ).build(),
-          Record(Set(Inventory.inventoryId, Inventory.price, Inventory.minPrice))(
-            Inventory.inventoryId ~> 101 &
-            Inventory.price ~> 19.99 &
-            Inventory.minPrice ~> 14.00
-          ).build()
-        )))
+        probe.expectMsg(StoreSection.GetPrice.Success(Relation(Seq(
+                  Record(Set(Inventory.inventoryId, Inventory.price, Inventory.minPrice))(
+                    Inventory.inventoryId ~> 100 &
+                    Inventory.price ~> 9.99 &
+                    Inventory.minPrice ~> 6.39
+                  ).build(),
+                  Record(Set(Inventory.inventoryId, Inventory.price, Inventory.minPrice))(
+                    Inventory.inventoryId ~> 101 &
+                    Inventory.price ~> 19.99 &
+                    Inventory.minPrice ~> 14.00
+                  ).build()
+                ))))
       }
 
       "return empty when calling GetPrice for non-existent inventoryIds" in {
         val probe = new TestProbe(system)
         storeSection1.tell(StoreSection.GetPrice.Request(Seq(10, 11)), probe.ref)
-        probe.expectMsg(StoreSection.GetPrice.Success(Seq.empty))
+        probe.expectMsg(StoreSection.GetPrice.Success(Relation(Seq.empty)))
       }
 
       // TODO Failure cases
@@ -106,24 +106,24 @@ class StoreSectionTest(_system: ActorSystem)
         storeSection1.tell(StoreSection.GetVariableDiscountUpdateInventory.Request(
           customerId, cartTime, orderItems1
         ), probe.ref)
-        probe.expectMsg(StoreSection.GetVariableDiscountUpdateInventory.Success(Seq(
-          Record(Set(amountCol, fixedDiscCol, varDiscCol))(
-            amountCol ~> 19.98 &
-            fixedDiscCol ~> 2.0 &
-            varDiscCol ~> 0
-          ).build()
-        )))
+        probe.expectMsg(StoreSection.GetVariableDiscountUpdateInventory.Success(Relation(Seq(
+                  Record(Set(amountCol, fixedDiscCol, varDiscCol))(
+                    amountCol ~> 19.98 &
+                    fixedDiscCol ~> 2.0 &
+                    varDiscCol ~> 0
+                  ).build()
+                ))))
 
         storeSection1.tell(StoreSection.GetVariableDiscountUpdateInventory.Request(
           customerId, cartTime, orderItems2
         ), probe.ref)
-        probe.expectMsg(StoreSection.GetVariableDiscountUpdateInventory.Success(Seq(
-          Record(Set(amountCol, fixedDiscCol, varDiscCol))(
-            amountCol ~> 29.97 &
-              fixedDiscCol ~> 3.0 &
-              varDiscCol ~> 4.5
-          ).build()
-        )))
+        probe.expectMsg(StoreSection.GetVariableDiscountUpdateInventory.Success(Relation(Seq(
+                  Record(Set(amountCol, fixedDiscCol, varDiscCol))(
+                    amountCol ~> 29.97 &
+                      fixedDiscCol ~> 3.0 &
+                      varDiscCol ~> 4.5
+                  ).build()
+                ))))
       }
     }
   }

--- a/sampleapp/src/test/scala/de/up/hpi/informationsystems/sampleapp/test/dactors/SystemTest.scala
+++ b/sampleapp/src/test/scala/de/up/hpi/informationsystems/sampleapp/test/dactors/SystemTest.scala
@@ -10,6 +10,7 @@ import de.up.hpi.informationsystems.adbms.definition.ColumnTypeDefaults._
 import de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.InsertIntoRelation
 import de.up.hpi.informationsystems.adbms.record.ColumnCellMapping._
 import de.up.hpi.informationsystems.adbms.record.Record
+import de.up.hpi.informationsystems.adbms.relation.Relation
 import de.up.hpi.informationsystems.sampleapp.dactors.Cart.{CartInfo, CartPurchases}
 import de.up.hpi.informationsystems.sampleapp.dactors.Customer.{CustomerInfo, StoreVisits}
 import de.up.hpi.informationsystems.sampleapp.dactors.GroupManager.Discounts
@@ -163,7 +164,7 @@ class SystemTest(_system: ActorSystem)
           sectionId = 14,
           quantity = 20
         )), 22), probe.ref)
-        probe.expectMsg(Cart.AddItems.Success(Seq(Record(Set(ColumnDef[Int]("session_id")))(ColumnDef[Int]("session_id") ~> 1).build())))
+        probe.expectMsg(Cart.AddItems.Success(Relation(Seq(Record(Set(ColumnDef[Int]("session_id")))(ColumnDef[Int]("session_id") ~> 1).build()))))
 
 //        cart42.tell(Cart.AddItems.Request(Seq.empty, 22), probe.ref)
 //        probe.expectMsg(Cart.AddItems.Success(Seq(Record(Set(ColumnDef[Int]("session_id")))(ColumnDef[Int]("session_id") ~> 2).build())))


### PR DESCRIPTION
<!-- Optional: -->
Fixes #68

## Proposed Changes

  - All successful response messages of the `RequestResponseProtocol` have a `result` object of type `Relation`

## Related

  - #68 
