### PR TITLE
Add DefaultMessagingProtocol.RelationQuery

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
@@ -31,7 +31,7 @@ trait DefaultMessageHandling extends Dactor {
       }
     case DefaultMessagingProtocol.RelationQuery(relationName) =>
       handleGenericRelationQuery(relationName) match {
-        case util.Success(relation) => sender() ! DefaultMessagingProtocol.RelationQueryResponse(relation)
+        case util.Success(relation) => sender() ! DefaultMessagingProtocol.RelationQuerySuccess(relation)
         case util.Failure(e) => sender() ! akka.actor.Status.Failure(e)
       }
   }
@@ -47,7 +47,13 @@ trait DefaultMessageHandling extends Dactor {
     relationFromName(relationName).insertAll(records).map(_.count(_ => true))
   }.flatten
 
-  // TODO add scaladoc
+  /**
+    * Returns an immutable copy of the requested relation if the `Dactor` has a `Relation` of this name,
+    * otherwise returns a [[NoSuchElementException]] Failure.
+    *
+    * @param relationName
+    * @return an immutable copy of the requested `Relation` or a [[NoSuchElementException]]
+    */
   private def handleGenericRelationQuery(relationName: String): Try[Relation] = Try{
     relationFromName(relationName).immutable
   }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
@@ -2,6 +2,7 @@ package de.up.hpi.informationsystems.adbms.protocols
 
 import de.up.hpi.informationsystems.adbms.Dactor
 import de.up.hpi.informationsystems.adbms.record.Record
+import de.up.hpi.informationsystems.adbms.relation.Relation
 
 import scala.util.Try
 
@@ -28,6 +29,11 @@ trait DefaultMessageHandling extends Dactor {
         case util.Success(_) => sender() ! akka.actor.Status.Success
         case util.Failure(e) => sender() ! akka.actor.Status.Failure(e)
       }
+    case DefaultMessagingProtocol.RelationQuery(relationName) =>
+      handleGenericRelationQuery(relationName) match {
+        case util.Success(relation) => sender() ! DefaultMessagingProtocol.RelationQueryResponse(relation)
+        case util.Failure(e) => sender() ! akka.actor.Status.Failure(e)
+      }
   }
 
   /**
@@ -41,4 +47,8 @@ trait DefaultMessageHandling extends Dactor {
     relationFromName(relationName).insertAll(records).map(_.count(_ => true))
   }.flatten
 
+  // TODO add scaladoc
+  private def handleGenericRelationQuery(relationName: String): Try[Relation] = Try{
+    relationFromName(relationName).immutable
+  }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
@@ -29,10 +29,10 @@ trait DefaultMessageHandling extends Dactor {
         case util.Success(_) => sender() ! akka.actor.Status.Success
         case util.Failure(e) => sender() ! akka.actor.Status.Failure(e)
       }
-    case DefaultMessagingProtocol.RelationQuery(relationName) =>
+    case DefaultMessagingProtocol.SelectAllFromRelation.Request(relationName) =>
       handleGenericRelationQuery(relationName) match {
-        case util.Success(relation) => sender() ! DefaultMessagingProtocol.RelationQuerySuccess(relation)
-        case util.Failure(e) => sender() ! akka.actor.Status.Failure(e)
+        case util.Success(relation) => sender() ! DefaultMessagingProtocol.SelectAllFromRelation.Success(relation)
+        case util.Failure(e) => sender() ! DefaultMessagingProtocol.SelectAllFromRelation.Failure(e)
       }
   }
 

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
@@ -18,7 +18,22 @@ object DefaultMessagingProtocol {
     */
   case class InsertIntoRelation(relation: String, records: Seq[Record])
 
-  // TODO add scaladoc
+  /**
+    * Use this message to request the contents of a relation from a `Dactor` implementing
+    * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
+    * The `Dactor` will return a
+    * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.RelationQuerySuccess]]
+    * message in case of success, or a [[akka.actor.Status.Failure]] in case of failure.
+    * @note Use with caution! This message relies on internal details of `Dactor`s and could lead to tight coupling.
+    * @param relation name of the requested relation
+    */
   case class RelationQuery(relation: String)
-  case class RelationQueryResponse(relation: Relation)
+
+  /**
+    * Message type returned after successful processing of a
+    * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.RelationQuery]]
+    * by `Dactor`s implementing [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
+    * @param relation immutable copy of the requested relation
+    */
+  case class RelationQuerySuccess(relation: Relation)
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
@@ -12,6 +12,7 @@ object DefaultMessagingProtocol {
     * Use this message to directly insert data into the relations of a `Dactor` implementing
     * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
     * The `Dactor`s will return with a message from [[akka.actor.Status]].
+    *
     * @note Use with caution! This message relies on internal details of `Dactor`s and could lead to tight coupling.
     * @param relation name of the relation in regards
     * @param records to be inserted records
@@ -24,6 +25,7 @@ object DefaultMessagingProtocol {
     * The `Dactor` will return a
     * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.RelationQuerySuccess]]
     * message in case of success, or a [[akka.actor.Status.Failure]] in case of failure.
+    *
     * @note Use with caution! This message relies on internal details of `Dactor`s and could lead to tight coupling.
     * @param relation name of the requested relation
     */
@@ -33,6 +35,7 @@ object DefaultMessagingProtocol {
     * Message type returned after successful processing of a
     * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.RelationQuery]]
     * by `Dactor`s implementing [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
+    *
     * @param relation immutable copy of the requested relation
     */
   case class RelationQuerySuccess(relation: Relation)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
@@ -1,6 +1,7 @@
 package de.up.hpi.informationsystems.adbms.protocols
 
 import de.up.hpi.informationsystems.adbms.record.Record
+import de.up.hpi.informationsystems.adbms.relation.Relation
 
 /**
   * Provides default messages for the `adbms` framework.
@@ -17,4 +18,7 @@ object DefaultMessagingProtocol {
     */
   case class InsertIntoRelation(relation: String, records: Seq[Record])
 
+  // TODO add scaladoc
+  case class RelationQuery(relation: String)
+  case class RelationQueryResponse(relation: Relation)
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessagingProtocol.scala
@@ -19,24 +19,36 @@ object DefaultMessagingProtocol {
     */
   case class InsertIntoRelation(relation: String, records: Seq[Record])
 
-  /**
-    * Use this message to request the contents of a relation from a `Dactor` implementing
-    * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
-    * The `Dactor` will return a
-    * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.RelationQuerySuccess]]
-    * message in case of success, or a [[akka.actor.Status.Failure]] in case of failure.
-    *
-    * @note Use with caution! This message relies on internal details of `Dactor`s and could lead to tight coupling.
-    * @param relation name of the requested relation
-    */
-  case class RelationQuery(relation: String)
 
-  /**
-    * Message type returned after successful processing of a
-    * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.RelationQuery]]
-    * by `Dactor`s implementing [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
-    *
-    * @param relation immutable copy of the requested relation
-    */
-  case class RelationQuerySuccess(relation: Relation)
+  object SelectAllFromRelation {
+    /**
+      * Use this message to request the contents of a relation from a `Dactor` implementing
+      * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
+      * The `Dactor` will return a
+      * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.SelectAllFromRelation.Success]]
+      * message in case of success, or a [[akka.actor.Status.Failure]] in case of failure.
+      *
+      * @note Use with caution! This message relies on internal details of `Dactor`s and could lead to tight coupling.
+      * @param relation name of the requested relation
+      */
+    case class Request(relation: String)
+
+    /**
+      * Message type returned after successful processing of a
+      * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.SelectAllFromRelation.Request]]
+      * by `Dactor`s implementing [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
+      *
+      * @param relation immutable copy of the requested relation
+      */
+    case class Success(relation: Relation)
+
+    /**
+      * Message type returned after failed processing of a
+      * [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.SelectAllFromRelation.Request]]
+      * by `Dactor`s implementing [[de.up.hpi.informationsystems.adbms.protocols.DefaultMessageHandling]].
+      *
+      * @param cause throwable failure
+      */
+    case class Failure(cause: Throwable)
+  }
 }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/DactorTest.scala
@@ -187,9 +187,9 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
         probe.expectMsg(akka.actor.Status.Success)
 
         "return an immutable copy of existing relation" in {
-          val queryMessage = DefaultMessagingProtocol.RelationQuery(TestRelation.name)
+          val queryMessage = DefaultMessagingProtocol.SelectAllFromRelation.Request(TestRelation.name)
           dut.tell(queryMessage, probe.ref)
-          val response = probe.expectMsgType[DefaultMessagingProtocol.RelationQuerySuccess]
+          val response = probe.expectMsgType[DefaultMessagingProtocol.SelectAllFromRelation.Success]
           response.relation.records shouldEqual util.Success(Seq(
             Record(TestRelation.columns)(
               TestRelation.col1 ~> 1 &
@@ -207,10 +207,10 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
         }
 
         "fail on requests for non existing relations" in {
-          val queryMessage = DefaultMessagingProtocol.RelationQuery("fail_please")
+          val queryMessage = DefaultMessagingProtocol.SelectAllFromRelation.Request("fail_please")
           dut.tell(queryMessage, probe.ref)
-          val response = probe.expectMsgType[akka.actor.Status.Failure]
-          response.cause shouldBe a[NoSuchElementException]
+          val failure = probe.expectMsgType[DefaultMessagingProtocol.SelectAllFromRelation.Failure]
+          failure.cause shouldBe a[NoSuchElementException]
         }
       }
     }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/DactorTest.scala
@@ -189,7 +189,7 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
         "return an immutable copy of existing relation" in {
           val queryMessage = DefaultMessagingProtocol.RelationQuery(TestRelation.name)
           dut.tell(queryMessage, probe.ref)
-          val response = probe.expectMsgType[DefaultMessagingProtocol.RelationQueryResponse]
+          val response = probe.expectMsgType[DefaultMessagingProtocol.RelationQuerySuccess]
           response.relation.records shouldEqual util.Success(Seq(
             Record(TestRelation.columns)(
               TestRelation.col1 ~> 1 &
@@ -210,7 +210,7 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
           val queryMessage = DefaultMessagingProtocol.RelationQuery("fail_please")
           dut.tell(queryMessage, probe.ref)
           val response = probe.expectMsgType[akka.actor.Status.Failure]
-          response.cause shouldBe a[java.util.NoSuchElementException]
+          response.cause shouldBe a[NoSuchElementException]
         }
       }
     }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/DactorTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/DactorTest.scala
@@ -131,8 +131,7 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
       }
 
       "relations available" should {
-        import DactorTest.DactorWithRelation.TestRelation
-        import DactorTest.DactorWithRelation.testRelationRecords
+        import DactorTest.DactorWithRelation.{TestRelation, testRelationRecords}
 
         val probe = TestProbe()
         val dut = Dactor.dactorOf(system, classOf[DactorTest.DactorWithRelation], 1)
@@ -168,8 +167,7 @@ class DactorTest extends TestKit(ActorSystem("test-system"))
       }
 
       "prefilled relations available" should {
-        import DactorTest.DactorWithRelation.TestRelation
-        import DactorTest.DactorWithRelation.testRelationRecords
+        import DactorTest.DactorWithRelation.{TestRelation, testRelationRecords}
 
         val probe = TestProbe()
         val dut = Dactor.dactorOf(system, classOf[DactorTest.DactorWithRelation], 2)


### PR DESCRIPTION
# `DefaultMessagingProtocol.RelationQuery`

A RelationQuery(relationName) returns the entire Relation with the
corresponding name from a Dactor if it exists. There is a specific
success message type for this case. In case of failure, e.g. no relation
of the given name existing with the Dactor, a akka.actor.Status.Failure
is returned.

This functionality can be used for tests and benchmarks and should not
necessarily be user-facing. The same is true, as we have discussed at
some point, for the DefaultMessagingProtocol.InsertIntoRelation
functionality which is why I think this is OK.

## Proposed Changes

  - Add DefaultMessagingProtocol.RelationQuery which can be used to request entire `Relations` from `Dactors`
  - This can be used with single-row `Relations` such as all `Info` relations and I implemented this for a new sample application in which I investigate how to implement `MultiDactorFunctions`

## Related

  - somewhat #64 but no need to implement it beforehand
