### PR TITLE
Fix equals, hashCode and clone methods in ColumnDef

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
@@ -80,23 +80,12 @@ final class ColumnDef[T](pName: String, pDefault: T)(implicit ct: ClassTag[T]) e
 
   override def toString: String = s"""${this.getClass.getSimpleName}[$tpe](name="$name", default=$default)"""
 
-  override def hashCode(): Int = Objects.hash(name, tpe) * (if(default != null) 12 + default.hashCode() else 1)
+  override def hashCode(): Int = Objects.hash(name, tpe) + (if(default == null) 0 else default.hashCode())
 
-  override def equals(o: Any): Boolean = {
-    def equalsIfNotNull(defaultValue1: Any, defaultValue2: Any): Boolean = (defaultValue1, defaultValue2) match {
-      case (d1, d2) if d1 == null && d2 == null => true
-      case (d1, d2) if d1 == null || d2 == null => false
-      case (d1, d2)                             => d1.equals(d2)
-    }
+  def canEqual(o: Any): Boolean = o.isInstanceOf[ColumnDef[T]]
 
-    if (o == null || getClass != o.getClass)
-      false
-    else {
-      // cast other object
-      val otherTypedColumnDef: ColumnDef[T] = o.asInstanceOf[ColumnDef[T]]
-
-      this.name.equals(otherTypedColumnDef.name) && this.tpe.equals(otherTypedColumnDef.tpe) &&
-        equalsIfNotNull(this.default, otherTypedColumnDef.default)
-    }
+  override def equals(o: Any): Boolean = o match {
+    case o: ColumnDef[T] => o.canEqual(this) && this.hashCode() == o.hashCode()
+    case _ => false
   }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
@@ -80,6 +80,9 @@ final class ColumnDef[T](pName: String, pDefault: T)(implicit ct: ClassTag[T]) e
 
   override def toString: String = s"""${this.getClass.getSimpleName}[$tpe](name="$name", default=$default)"""
 
+  // proper way to implement equals() in scala:
+  // https://www.safaribooksonline.com/library/view/scala-cookbook/9781449340292/ch04s16.html
+  // -----
   override def hashCode(): Int = Objects.hash(name, tpe) + (if(default == null) 0 else default.hashCode())
 
   def canEqual(o: Any): Boolean = o.isInstanceOf[ColumnDef[T]]
@@ -88,4 +91,5 @@ final class ColumnDef[T](pName: String, pDefault: T)(implicit ct: ClassTag[T]) e
     case o: ColumnDef[T] => o.canEqual(this) && this.hashCode() == o.hashCode()
     case _ => false
   }
+  // -----
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
@@ -82,7 +82,7 @@ final class ColumnDef[T](pName: String, pDefault: T)(implicit ct: ClassTag[T]) e
 
   override def hashCode(): Int = Objects.hash(name, tpe) * (if(default != null) 12 + default.hashCode() else 1)
 
-  override def equals(o: scala.Any): Boolean = {
+  override def equals(o: Any): Boolean = {
     def equalsIfNotNull(d1: Any, d2: Any): Boolean =
       if (d1 == null && d2 == null) true
       else if (d1 == null || d2 == null) false
@@ -101,6 +101,4 @@ final class ColumnDef[T](pName: String, pDefault: T)(implicit ct: ClassTag[T]) e
         false
     }
   }
-
-  override def clone(): AnyRef = new ColumnDef[T](this.name, this.default)(this.tpe)
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDef.scala
@@ -83,22 +83,20 @@ final class ColumnDef[T](pName: String, pDefault: T)(implicit ct: ClassTag[T]) e
   override def hashCode(): Int = Objects.hash(name, tpe) * (if(default != null) 12 + default.hashCode() else 1)
 
   override def equals(o: Any): Boolean = {
-    def equalsIfNotNull(d1: Any, d2: Any): Boolean =
-      if (d1 == null && d2 == null) true
-      else if (d1 == null || d2 == null) false
-      else d1.equals(d2)
+    def equalsIfNotNull(defaultValue1: Any, defaultValue2: Any): Boolean = (defaultValue1, defaultValue2) match {
+      case (d1, d2) if d1 == null && d2 == null => true
+      case (d1, d2) if d1 == null || d2 == null => false
+      case (d1, d2)                             => d1.equals(d2)
+    }
 
     if (o == null || getClass != o.getClass)
       false
     else {
       // cast other object
       val otherTypedColumnDef: ColumnDef[T] = o.asInstanceOf[ColumnDef[T]]
-      if (this.name.equals(otherTypedColumnDef.name) &&
-        this.tpe.equals(otherTypedColumnDef.tpe) &&
-        equalsIfNotNull(this.default, otherTypedColumnDef.default))
-        true
-      else
-        false
+
+      this.name.equals(otherTypedColumnDef.name) && this.tpe.equals(otherTypedColumnDef.tpe) &&
+        equalsIfNotNull(this.default, otherTypedColumnDef.default)
     }
   }
 }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDefTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/definition/ColumnDefTest.scala
@@ -85,13 +85,6 @@ class ColumnDefTest extends WordSpec with Matchers {
       colInt.untyped.hashCode() shouldNot equal(ColumnDef[Int]("integerColumn", 12).untyped.hashCode())
     }
 
-    "provide clones of itself" in {
-      val cloneColInt = colInt.clone()
-
-      colInt should equal(cloneColInt)
-      colInt shouldNot be theSameInstanceAs cloneColInt
-    }
-
     "contain its type in form of a classTag" in {
       colInt.tpe should equal(classTag[Int])
       colInt.tpe shouldNot equal(classTag[Byte])


### PR DESCRIPTION
<!-- Optional: -->
Fixes #94

## Proposed Changes

  - improved `hashCode` and `equals` implementations of `ColumnDef[T]` class
  - removed `clone`-method

