### PR TITLE
Fix/other equals

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/record/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/record/Record.scala
@@ -58,7 +58,7 @@ class Record private (cells: Map[UntypedColumnDef, Any])
     * Use [[de.up.hpi.informationsystems.adbms.record.Record#get]] instead!
     * It takes care of types!
     */
-  @Deprecated
+  @deprecated
   override def get(key: UntypedColumnDef): Option[Any] = get(key.asInstanceOf[ColumnDef[Any]])
 
   override def iterator: Iterator[(UntypedColumnDef, Any)] = data.iterator

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/record/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/record/Record.scala
@@ -86,17 +86,12 @@ class Record private (cells: Map[UntypedColumnDef, Any])
 
   override def hashCode(): Int = Objects.hash(columns, data)
 
-  override def equals(o: scala.Any): Boolean =
-    if (o == null || getClass != o.getClass)
-      false
-    else {
-      // cast other object
-      val otherRecord: Record = o.asInstanceOf[Record]
-      if (this.columns.equals(otherRecord.columns) && this.data.equals(otherRecord.data))
-        true
-      else
-        false
-    }
+  override def canEqual(o: Any): Boolean = o.isInstanceOf[Record]
+
+  override def equals(o: Any): Boolean = o match {
+    case that: Record => that.canEqual(this) && this.columns.equals(that.columns) && this.data.equals(that.data)
+    case _ => false
+  }
 
   // FIXME: I don't know what to do here.
   // removing this line leads to a compiler error

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelation.scala
@@ -1,5 +1,7 @@
 package de.up.hpi.informationsystems.adbms.relation
 
+import java.util.Objects
+
 import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, UntypedColumnDef}
 import de.up.hpi.informationsystems.adbms.record.Record
 import de.up.hpi.informationsystems.adbms.{IncompatibleColumnDefinitionException, Util}
@@ -18,13 +20,15 @@ private[relation] final class TransientRelation(data: Try[Seq[Record]]) extends 
     else
       data.get.head.columns
 
-  /** @inheritdoc*/
-  override def equals(obj: scala.Any): Boolean =
-    obj.isInstanceOf[TransientRelation] &&
-      (hashCode() == obj.asInstanceOf[TransientRelation].hashCode())
+  override def hashCode(): Int = Objects.hashCode(internal_data, isFailure, columns)
 
-  override def hashCode(): Int =
-    internal_data.hashCode() + isFailure.hashCode() + columns.hashCode()
+  def canEqual(o: Any): Boolean = o.isInstanceOf[TransientRelation]
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: TransientRelation => that.canEqual(this) && this.hashCode() == that.hashCode()
+    case _ => false
+  }
+
 
   /** @inheritdoc */
   override def where[T](f: (ColumnDef[T], T => Boolean)): Relation =


### PR DESCRIPTION
## Proposed Changes

  - Fixing `equals` in `TransientRelation` and `Record`
  - Switched from java- to scala-implementation-pattern

## Related

  - Issue #94 
  - PR #95 
