### PR TITLE
Preparation for RelationImpl. changes / Fix handling of combinations of relation types

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/FutureRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/FutureRelation.scala
@@ -77,25 +77,25 @@ object FutureRelation {
     private type BinRelationOp = (Relation, Relation) => Relation
 
     def innerJoin(relation1: FutureRelation, relation2: Relation, on: RecordComparator): FutureRelation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.innerJoin(rel2, on))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.innerJoin(rel2, on))
 
     def outerJoin(relation1: FutureRelation, relation2: Relation, on: RecordComparator): FutureRelation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.outerJoin(rel2, on))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.outerJoin(rel2, on))
 
     def leftJoin(relation1: FutureRelation, relation2: Relation, on: RecordComparator): FutureRelation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.leftJoin(rel2, on))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.leftJoin(rel2, on))
 
     def rightJoin(relation1: FutureRelation, relation2: Relation, on: RecordComparator): FutureRelation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.rightJoin(rel2, on))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.rightJoin(rel2, on))
 
     def innerEquiJoin[T](relation1: FutureRelation, relation2: Relation, on: (ColumnDef[T], ColumnDef[T])): FutureRelation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.innerEquiJoin(rel2, on))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.innerEquiJoin(rel2, on))
 
     def union(relation1: FutureRelation, relation2: Relation): FutureRelation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.union(rel2))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.union(rel2))
 
     def unionAll(relation1: FutureRelation, relation2: Relation): Relation =
-      futureCheckedBinaryTransformation(relation1, relation2, (rel1, rel2) => rel1.unionAll(rel2))
+      futureCheckedBinaryOperation(relation1, relation2, (rel1, rel2) => rel1.unionAll(rel2))
 
     /**
       * Creates a new Relation from `relation1` and `relation2` by applying `op` to them.
@@ -108,7 +108,7 @@ object FutureRelation {
       * @param op         BinRelationOp to apply
       * @return           a new Relation returned from `op` after application to `relation1` and `relation2`
       */
-    private def futureCheckedBinaryTransformation(relation1: FutureRelation, relation2: Relation, op: BinRelationOp): FutureRelation =
+    private def futureCheckedBinaryOperation(relation1: FutureRelation, relation2: Relation, op: BinRelationOp): FutureRelation =
       FutureRelation(
         relation2 match {
           case fr: FutureRelation => for {

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
@@ -7,26 +7,36 @@ import scala.util.Try
 
 object MutableRelation {
   object BinOps {
+
+    private type BinRelationOp = (Relation, Relation) => Relation
+
     def innerJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
-      relation1.immutable.innerJoin(relation2, on)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.innerJoin(rel2, on))
 
     def outerJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
-      relation1.immutable.outerJoin(relation2, on)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.outerJoin(rel2, on))
 
     def leftJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
-      relation1.immutable.leftJoin(relation2, on)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.leftJoin(rel2, on))
 
     def rightJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
-      relation1.rightJoin(relation2, on)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.rightJoin(rel2, on))
 
     def innerEquiJoin[T](relation1: MutableRelation, relation2: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation =
-      relation1.immutable.innerEquiJoin(relation2, on)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.innerEquiJoin(rel2, on))
 
     def union(relation1: MutableRelation, relation2: Relation): Relation =
-      relation1.immutable.union(relation2)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.union(rel2))
 
     def unionAll(relation1: MutableRelation, relation2: Relation): Relation =
-      relation1.immutable.unionAll(relation2)
+      checkedBinaryOp(relation1, relation2, (rel1, rel2) => rel1.unionAll(rel2))
+
+    private def checkedBinaryOp(relation1: MutableRelation, relation2: Relation, op: BinRelationOp): Relation =
+      relation2 match {
+        case otherRel: MutableRelation => op(relation1.immutable, otherRel.immutable)
+        case otherRel: TransientRelation => op(relation1.immutable, otherRel)
+        case r => throw new UnsupportedOperationException(s"${r.getClass.getSimpleName} can not be an operand to a binary operation on MutableRelation")
+      }
   }
 }
 trait MutableRelation extends Relation {

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
@@ -5,6 +5,30 @@ import de.up.hpi.informationsystems.adbms.record.{ColumnCellMapping, Record}
 
 import scala.util.Try
 
+object MutableRelation {
+  object BinOps {
+    def innerJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
+      relation1.immutable.innerJoin(relation2, on)
+
+    def outerJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
+      relation1.immutable.outerJoin(relation2, on)
+
+    def leftJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
+      relation1.immutable.leftJoin(relation2, on)
+
+    def rightJoin(relation1: MutableRelation, relation2: Relation, on: Relation.RecordComparator): Relation =
+      relation1.rightJoin(relation2, on)
+
+    def innerEquiJoin[T](relation1: MutableRelation, relation2: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation =
+      relation1.immutable.innerEquiJoin(relation2, on)
+
+    def union(relation1: MutableRelation, relation2: Relation): Relation =
+      relation1.immutable.union(relation2)
+
+    def unionAll(relation1: MutableRelation, relation2: Relation): Relation =
+      relation1.immutable.unionAll(relation2)
+  }
+}
 trait MutableRelation extends Relation {
 
   /**

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
@@ -39,6 +39,7 @@ object MutableRelation {
       }
   }
 }
+
 trait MutableRelation extends Relation {
 
   /**

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/Relation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/Relation.scala
@@ -51,70 +51,6 @@ trait Relation {
   def project(columnDefs: Set[UntypedColumnDef]): Relation
 
   /**
-    * Performs an inner join with another relation on a comparator function.
-    *
-    * @param other relation to join with
-    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
-    *          pairs of records from the respective relations are in the result set. The
-    *          result set contains exactly the records made up of the pairs of records for
-    *          which `on` returns `true`.
-    * @return a new relation comprised of the joined records from `this` and `other`
-    */
-  def innerJoin(other: Relation, on: Relation.RecordComparator): Relation
-
-  /**
-    * Performs an outer join with another relation on a comparator function.
-    * @param other relation to join with
-    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
-    *          pairs of records from the respective relations are in the result set. The
-    *          result set contains exactly the records made up of the pairs of records for
-    *          which `on` returns `true`.
-    * @return a new relation comprised of the joined records from `this` and `other`
-    */
-  def outerJoin(other: Relation, on: Relation.RecordComparator): Relation
-
-  /**
-    * Performs an left join with another relation on a comparator function.
-    * @param other relation to join with
-    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
-    *          pairs of records from the respective relations are in the result set. The
-    *          result set contains exactly the records made up of the pairs of records for
-    *          which `on` returns `true`.
-    * @return a new relation comprised of the joined records from `this` and `other`
-    */
-  def leftJoin(other: Relation, on: Relation.RecordComparator): Relation
-
-  /**
-    * Performs an right join with another relation on a comparator function.
-    * @param other relation to join with
-    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
-    *          pairs of records from the respective relations are in the result set. The
-    *          result set contains exactly the records made up of the pairs of records for
-    *          which `on` returns `true`.
-    * @return a new relation comprised of the joined records from `this` and `other`
-    */
-  def rightJoin(other: Relation, on: Relation.RecordComparator): Relation
-
-  /**
-    * Performs an equality join of this relation with another one on the specified columns.
-    *
-    * @note Currently the column types of the join columns must be the same!
-    * @param other relation to join with
-    * @param on tuple of `ColumnDef[T]`s which determine which columns' attributes are
-    *           compared for the equality join
-    * @tparam T
-    * @return a new relation comprised of the joined records from `this` and `other`
-    */
-  def innerEquiJoin[T](other: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation
-
-  /**
-    * Performs a union with another relation, iff the relations have the same schema definition.
-    * @param other relation to join with
-    * @return a new relation containing the records from both relations
-    */
-  def union(other: Relation): Relation
-
-  /**
     * Applies `f` on all values of the column `col`.
     * @param col column, whos values should be changed
     * @param f transformation function
@@ -137,5 +73,86 @@ trait Relation {
     * @return initialized RecordBuilder
     */
   def newRecord: RecordBuilder = Record(columns)
+
+  // binary operations are handle by RelationBinOps class
+  /**
+    * Performs an inner join with another relation on a comparator function.
+    *
+    * @param other relation to join with
+    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
+    *          pairs of records from the respective relations are in the result set. The
+    *          result set contains exactly the records made up of the pairs of records for
+    *          which `on` returns `true`.
+    * @return a new relation comprised of the joined records from `this` and `other`
+    */
+  final def innerJoin(other: Relation, on: Relation.RecordComparator): Relation =
+    RelationBinOps.innerJoin(this, other, on)
+
+  /**
+    * Performs an outer join with another relation on a comparator function.
+    * @param other relation to join with
+    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
+    *          pairs of records from the respective relations are in the result set. The
+    *          result set contains exactly the records made up of the pairs of records for
+    *          which `on` returns `true`.
+    * @return a new relation comprised of the joined records from `this` and `other`
+    */
+  final def outerJoin(other: Relation, on: Relation.RecordComparator): Relation =
+    RelationBinOps.outerJoin(this, other, on)
+
+  /**
+    * Performs an left join with another relation on a comparator function.
+    * @param other relation to join with
+    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
+    *          pairs of records from the respective relations are in the result set. The
+    *          result set contains exactly the records made up of the pairs of records for
+    *          which `on` returns `true`.
+    * @return a new relation comprised of the joined records from `this` and `other`
+    */
+  final def leftJoin(other: Relation, on: Relation.RecordComparator): Relation =
+    RelationBinOps.leftJoin(this, other, on)
+
+  /**
+    * Performs an right join with another relation on a comparator function.
+    * @param other relation to join with
+    * @param on `RecordComparator`, i.e. (Record, Record) => Boolean, which determines which
+    *          pairs of records from the respective relations are in the result set. The
+    *          result set contains exactly the records made up of the pairs of records for
+    *          which `on` returns `true`.
+    * @return a new relation comprised of the joined records from `this` and `other`
+    */
+  final def rightJoin(other: Relation, on: Relation.RecordComparator): Relation =
+    RelationBinOps.rightJoin(this, other, on)
+
+  /**
+    * Performs an equality join of this relation with another one on the specified columns.
+    *
+    * @note Currently the column types of the join columns must be the same!
+    * @param other relation to join with
+    * @param on tuple of `ColumnDef[T]`s which determine which columns' attributes are
+    *           compared for the equality join
+    * @tparam T
+    * @return a new relation comprised of the joined records from `this` and `other`
+    */
+  final def innerEquiJoin[T](other: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation =
+    RelationBinOps.innerEquiJoin(this, other, on)
+
+  /**
+    * Performs a union with another relation, iff the relations have the same schema definition,
+    * and removes duplicates.
+    *
+    * @param other relation to join with
+    * @return a new relation containing the distinct records from both relations
+    */
+  final def union(other: Relation): Relation =
+    RelationBinOps.union(this, other)
+
+  /**
+    * Performs a union with another relation, iff the relations have the same schema definition.
+    * @param other relation to join with
+    * @return a new relation containing all records from both relations
+    */
+  final def unionAll(other: Relation): Relation =
+    RelationBinOps.unionAll(this, other)
 
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
@@ -11,7 +11,7 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.innerJoin(fr, r, on)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.innerJoin(fr, mr, on)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.innerJoin(mr, r, on)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 
   def leftJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
@@ -21,7 +21,7 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.leftJoin(fr, r, on)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.rightJoin(fr, mr, on)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.leftJoin(mr, r, on)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 
   def rightJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
@@ -31,7 +31,7 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.rightJoin(fr, r, on)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.leftJoin(fr, mr, on)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.rightJoin(mr, r, on)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 
   def outerJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
@@ -41,7 +41,7 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.outerJoin(fr, r, on)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.outerJoin(fr, mr, on)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.outerJoin(mr, r, on)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 
   def innerEquiJoin[T](left: Relation, right: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation = (left, right) match {
@@ -51,7 +51,7 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.innerEquiJoin(fr, r, on)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.innerEquiJoin(fr, mr, on)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.innerEquiJoin(mr, r, on)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 
   def unionAll(left: Relation, right: Relation): Relation = (left, right) match {
@@ -61,7 +61,7 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.unionAll(fr, r)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.unionAll(fr, mr)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.unionAll(mr, r)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 
   def union(left: Relation, right: Relation): Relation = (left, right) match {
@@ -71,6 +71,6 @@ object RelationBinOps {
     case (fr: FutureRelation, r) => FutureRelation.BinOps.union(fr, r)
     case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.union(fr, mr)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.union(mr, r)
-    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not supported!")
   }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
@@ -8,57 +8,69 @@ object RelationBinOps {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerJoin(tr1, tr2, on)
     case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.innerJoin(fr, tr, on)
     case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.innerJoin(mr, tr, on)
-    case (_: TransientRelation, r) => throw new UnsupportedOperationException(s"Binary relation operation for ${r.getClass.getSimpleName} is not yet supported!")
     case (fr: FutureRelation, r) => FutureRelation.BinOps.innerJoin(fr, r, on)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.innerJoin(fr, mr, on)
     case (mr: MutableRelation, r) => MutableRelation.BinOps.innerJoin(mr, r, on)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 
   def leftJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.leftJoin(tr1, tr2, on)
-    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.leftJoin(fr, tr, on)
-    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.leftJoin(mr, tr, on)
-    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.leftJoin(fr, r, on)
-    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.leftJoin(mr, r, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.rightJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.rightJoin(mr, tr, on)
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.leftJoin(fr, r, on)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.rightJoin(fr, mr, on)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.leftJoin(mr, r, on)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 
   def rightJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.rightJoin(tr1, tr2, on)
-    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.rightJoin(fr, tr, on)
-    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.rightJoin(mr, tr, on)
-    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.rightJoin(fr, r, on)
-    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.rightJoin(mr, r, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.leftJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.leftJoin(mr, tr, on)
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.rightJoin(fr, r, on)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.leftJoin(fr, mr, on)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.rightJoin(mr, r, on)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 
   def outerJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.outerJoin(tr1, tr2, on)
     case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.outerJoin(fr, tr, on)
     case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.outerJoin(mr, tr, on)
-    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.outerJoin(fr, r, on)
-    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.outerJoin(mr, r, on)
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.outerJoin(fr, r, on)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.outerJoin(fr, mr, on)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.outerJoin(mr, r, on)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 
   def innerEquiJoin[T](left: Relation, right: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerEquiJoin(tr1, tr2, on)
-    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerEquiJoin(tr1, tr2, on)
     case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.innerEquiJoin(fr, tr, on)
     case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.innerEquiJoin(mr, tr, on)
-    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.innerEquiJoin(fr, r, on)
-    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.innerEquiJoin(mr, r, on)
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.innerEquiJoin(fr, r, on)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.innerEquiJoin(fr, mr, on)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.innerEquiJoin(mr, r, on)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 
   def unionAll(left: Relation, right: Relation): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.unionAll(tr1, tr2)
     case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.unionAll(fr, tr)
     case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.unionAll(mr, tr)
-    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.unionAll(fr, r)
-    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.unionAll(mr, r)
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.unionAll(fr, r)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.unionAll(fr, mr)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.unionAll(mr, r)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 
   def union(left: Relation, right: Relation): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.union(tr1, tr2)
     case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.union(fr, tr)
     case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.union(mr, tr)
-    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.union(fr, r)
-    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.union(mr, r)
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.union(fr, r)
+    case (mr: MutableRelation, fr: FutureRelation) => FutureRelation.BinOps.union(fr, mr)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.union(mr, r)
+    case (r1, r2) => throw new UnsupportedOperationException(s"Binary relation operation for ${r1.getClass.getSimpleName} and ${r2.getClass.getSimpleName} is not yet supported!")
   }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
@@ -1,0 +1,38 @@
+package de.up.hpi.informationsystems.adbms.relation
+
+import de.up.hpi.informationsystems.adbms.definition.ColumnDef
+
+object RelationBinOps {
+
+  def innerJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerJoin(tr1, tr2, on)
+//    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.innerJoin(fr, tr, on)
+//    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.innerJoin(mr, tr, on)
+//    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.innerJoin(fr, r, on)
+//    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.innerJoin(mr, r, on)
+  }
+
+  def leftJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.leftJoin(tr1, tr2, on)
+  }
+
+  def rightJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.rightJoin(tr1, tr2, on)
+  }
+
+  def outerJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.outerJoin(tr1, tr2, on)
+  }
+
+  def innerEquiJoin[T](left: Relation, right: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerEquiJoin(tr1, tr2, on)
+  }
+
+  def unionAll(left: Relation, right: Relation): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.unionAll(tr1, tr2)
+  }
+
+  def union(left: Relation, right: Relation): Relation = (left, right) match {
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.union(tr1, tr2)
+  }
+}

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOps.scala
@@ -6,33 +6,59 @@ object RelationBinOps {
 
   def innerJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerJoin(tr1, tr2, on)
-//    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.innerJoin(fr, tr, on)
-//    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.innerJoin(mr, tr, on)
-//    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.innerJoin(fr, r, on)
-//    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.innerJoin(mr, r, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.innerJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.innerJoin(mr, tr, on)
+    case (_: TransientRelation, r) => throw new UnsupportedOperationException(s"Binary relation operation for ${r.getClass.getSimpleName} is not yet supported!")
+    case (fr: FutureRelation, r) => FutureRelation.BinOps.innerJoin(fr, r, on)
+    case (mr: MutableRelation, r) => MutableRelation.BinOps.innerJoin(mr, r, on)
   }
 
   def leftJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.leftJoin(tr1, tr2, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.leftJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.leftJoin(mr, tr, on)
+    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.leftJoin(fr, r, on)
+    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.leftJoin(mr, r, on)
   }
 
   def rightJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.rightJoin(tr1, tr2, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.rightJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.rightJoin(mr, tr, on)
+    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.rightJoin(fr, r, on)
+    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.rightJoin(mr, r, on)
   }
 
   def outerJoin(left: Relation, right: Relation, on: Relation.RecordComparator): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.outerJoin(tr1, tr2, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.outerJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.outerJoin(mr, tr, on)
+    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.outerJoin(fr, r, on)
+    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.outerJoin(mr, r, on)
   }
 
   def innerEquiJoin[T](left: Relation, right: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerEquiJoin(tr1, tr2, on)
+    case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.innerEquiJoin(tr1, tr2, on)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.innerEquiJoin(fr, tr, on)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.innerEquiJoin(mr, tr, on)
+    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.innerEquiJoin(fr, r, on)
+    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.innerEquiJoin(mr, r, on)
   }
 
   def unionAll(left: Relation, right: Relation): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.unionAll(tr1, tr2)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.unionAll(fr, tr)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.unionAll(mr, tr)
+    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.unionAll(fr, r)
+    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.unionAll(mr, r)
   }
 
   def union(left: Relation, right: Relation): Relation = (left, right) match {
     case (tr1: TransientRelation, tr2: TransientRelation) => TransientRelation.BinOps.union(tr1, tr2)
+    case (tr: TransientRelation, fr: FutureRelation) => FutureRelation.BinOps.union(fr, tr)
+    case (tr: TransientRelation, mr: MutableRelation) => MutableRelation.BinOps.union(mr, tr)
+    case (fr: FutureRelation, r: Relation) => FutureRelation.BinOps.union(fr, r)
+    case (mr: MutableRelation, r: Relation) => MutableRelation.BinOps.union(mr, r)
   }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RowRelation.scala
@@ -79,30 +79,6 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
   /** @inheritdoc */
   override def project(columnDefs: Set[UntypedColumnDef]): Relation = Relation(data).project(columnDefs)
 
-  /** @inheritdoc*/
-  override def innerEquiJoin[T](other: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation =
-    Relation(data).innerEquiJoin(other, on)
-
-  /** @inheritdoc */
-  override def innerJoin(other: Relation, on: RecordComparator): Relation =
-    Relation(records).innerJoin(other, on)
-
-  /** @inheritdoc */
-  override def outerJoin(other: Relation, on: RecordComparator): Relation =
-    Relation(records).outerJoin(other, on)
-
-  /** @inheritdoc */
-  override def leftJoin(other: Relation, on: RecordComparator): Relation =
-    Relation(records).leftJoin(other, on)
-
-  /** @inheritdoc */
-  override def rightJoin(other: Relation, on: RecordComparator): Relation =
-    Relation(records).rightJoin(other, on)
-
-  /** @inheritdoc */
-  override def union(other: Relation): Relation =
-    Relation(records).union(other)
-
   /** @inheritdoc */
   override def applyOn[T](col: ColumnDef[T], f: T => T): Relation =
     Relation(records).applyOn(col, f)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelation.scala
@@ -159,26 +159,6 @@ private[relation] final class TransientRelation(data: Try[Seq[Record]]) extends 
           throw IncompatibleColumnDefinitionException(s"this relation does not contain all specified columns {$columnDefs}")
       ))
 
-  /** @inheritdoc */
-  override def innerJoin(other: Relation, on: Relation.RecordComparator): Relation =
-    RelationBinOps.innerJoin(this, other, on)
-
-  /** @inheritdoc */
-  override def leftJoin(other: Relation, on: Relation.RecordComparator): Relation =
-    RelationBinOps.leftJoin(this, other, on)
-
-  /** @inheritdoc */
-  override def rightJoin(other: Relation, on: Relation.RecordComparator): Relation =
-    RelationBinOps.rightJoin(this, other, on)
-
-  /** @inheritdoc */
-  override def outerJoin(other: Relation, on: Relation.RecordComparator): Relation =
-    RelationBinOps.outerJoin(this, other, on)
-
-  /** @inheritdoc */
-  override def innerEquiJoin[T](other: Relation, on: (ColumnDef[T], ColumnDef[T])): Relation =
-    RelationBinOps.innerEquiJoin(this, other, on)
-
   /** @inheritdoc*/
   override def applyOn[T](col: ColumnDef[T], f: T => T): Relation =
     if(isFailure || !Set(col).subsetOf(columns))
@@ -192,10 +172,6 @@ private[relation] final class TransientRelation(data: Try[Seq[Record]]) extends 
           case None => record
         })
       })
-
-  /** @inheritdoc */
-  override def union(other: Relation): Relation =
-    RelationBinOps.union(this, other)
 
   /** @inheritdoc */
   override def records: Try[Seq[Record]] = data

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOpsTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOpsTest.scala
@@ -1,0 +1,232 @@
+package de.up.hpi.informationsystems.adbms.relation
+
+import de.up.hpi.informationsystems.adbms.definition.ColumnTypeDefaults._
+import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef, UntypedColumnDef}
+import de.up.hpi.informationsystems.adbms.record.ColumnCellMapping._
+import de.up.hpi.informationsystems.adbms.record.Record
+import org.scalactic.Equality
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Success, Try}
+
+class RelationBinOpsTest extends WordSpec with Matchers {
+
+  // result sets are equal if their order is not!
+  implicit val sortedRecordSeqEquality: Equality[Try[Seq[Record]]] = new Equality[Try[Seq[Record]]] {
+
+    implicit val recordOrdering: Ordering[Record] = (x: Record, y: Record) => x.hashCode() - y.hashCode()
+
+    def areEqual(a: Try[Seq[Record]], b: Any): Boolean =
+      b match {
+        case Success(r: Seq[Record]) => a.get.sorted.equals(r.sorted)
+        case _ => false
+      }
+  }
+
+  val colFirstname: ColumnDef[String] = ColumnDef("Firstname")
+  val colLastname: ColumnDef[String] = ColumnDef("Lastname")
+  val colId: ColumnDef[Int] = ColumnDef("ID")
+
+  val columnSet1: Set[UntypedColumnDef] = Set(colId, colFirstname)
+  val columnSet2: Set[UntypedColumnDef] = Set(colId, colLastname)
+
+  val recSeq1: Seq[Record] = Seq(
+    Record(columnSet1)(
+      colId ~> 1 &
+      colFirstname ~> "Hans"
+    ).build(),
+    Record(columnSet1)(
+      colId ~> 2 &
+      colFirstname ~> "Peter"
+    ).build(),
+    Record(columnSet1)(
+      colId ~> 3 &
+      colFirstname ~> "Lisa"
+    ).build()
+  )
+  val recSeq2: Seq[Record] = Seq(
+    Record(columnSet2)(
+      colId ~> 1 &
+      colLastname ~> "Maier"
+    ).build(),
+    Record(columnSet2)(
+      colId ~> 2 &
+      colLastname ~> "Schubert"
+    ).build(),
+    Record(columnSet2)(
+      colId ~> 4 &
+      colLastname ~> "Gross"
+    ).build()
+  )
+
+  "A binary relation operation" when {
+
+    // transient relations
+    val TRunionRel = Relation(recSeq1)
+    val TRjoinRel = Relation(recSeq2)
+
+    // future relations
+    val FRunionRel = FutureRelation.fromRecordSeq(Future{
+      Thread.sleep(50)
+      recSeq1
+    })
+    val FRjoinRel = FutureRelation.fromRecordSeq(Future{
+      Thread.sleep(50)
+      recSeq2
+    })
+
+    // mutable relations
+    val RRunionRel = RowRelation(new RelationDef {
+      override val name: String = "unionRel"
+      override val columns: Set[UntypedColumnDef] = columnSet1
+    })
+    RRunionRel.insertAll(recSeq1)
+    val RRjoinRel = RowRelation(new RelationDef {
+      override val name: String = "joinRel"
+      override val columns: Set[UntypedColumnDef] = columnSet2
+    })
+    RRjoinRel.insertAll(recSeq2)
+
+
+    { // future relation tests
+      val rel1 = FutureRelation.fromRecordSeq(Future {
+        Thread.sleep(50)
+        recSeq1
+      })
+
+      "operands: FutureRelation, FutureRelation" should {
+        testUnionOperations(rel1, FRunionRel)
+        testJoinOperations(rel1, FRjoinRel)
+      }
+      "operands: FutureRelation, TransientRelation" should {
+        testUnionOperations(rel1, TRunionRel)
+        testJoinOperations(rel1, TRjoinRel)
+      }
+      "operands: FutureRelation, MutableRelation" should {
+        testUnionOperations(rel1, RRunionRel)
+        testJoinOperations(rel1, RRjoinRel)
+      }
+    }
+
+    { // transient relation tests
+      val rel1 = Relation(recSeq1)
+
+      "operands: TransientRelation, TransientRelation" should {
+        testUnionOperations(rel1, TRunionRel)
+        testJoinOperations(rel1, TRjoinRel)
+      }
+      "operands: TransientRelation, FutureRelation" should {
+        testUnionOperations(rel1, FRunionRel)
+        testJoinOperations(rel1, FRjoinRel)
+      }
+      "operands: TransientRelation, MutableRelation" should {
+        testUnionOperations(rel1, RRunionRel)
+        testJoinOperations(rel1, RRjoinRel)
+      }
+    }
+
+    { // mutable relation tests
+      val rel1 = RowRelation(new RelationDef {
+        override val name: String = "rel1"
+        override val columns: Set[UntypedColumnDef] = columnSet1
+      })
+      rel1.insertAll(recSeq1)
+
+      "operands: MutableRelation, TransientRelation" should {
+        testUnionOperations(rel1, TRunionRel)
+        testJoinOperations(rel1, TRjoinRel)
+      }
+      "operands: MutableRelation, FutureRelation" should {
+        testUnionOperations(rel1, FRunionRel)
+        testJoinOperations(rel1, FRjoinRel)
+      }
+      "operands: MutableRelation, MutableRelation" should {
+        testUnionOperations(rel1, RRunionRel)
+        testJoinOperations(rel1, RRjoinRel)
+      }
+    }
+  }
+
+  def testUnionOperations(rel1: Relation, unionRel: Relation): Unit = {
+    "support union" in {
+      val res1 = rel1.union(unionRel)
+      res1.columns shouldEqual columnSet1
+      res1.records shouldEqual Success(recSeq1)
+    }
+
+    "support unionAll" in {
+      val res2 = rel1.unionAll(unionRel)
+      res2.columns shouldEqual columnSet1
+      res2.records shouldEqual Success(recSeq1 ++ recSeq1)
+    }
+  }
+  
+  def testJoinOperations(rel1: Relation, joinRel: Relation): Unit = {
+    val joinRecordBuilder = Record(columnSet1 ++ columnSet2)
+    val joinIdCommonResult = Seq(
+      joinRecordBuilder(
+        colId ~> 1 &
+          colFirstname ~> "Hans" &
+          colLastname ~> "Maier"
+      ).build(),
+      joinRecordBuilder(
+        colId ~> 2 &
+          colFirstname ~> "Peter" &
+          colLastname ~> "Schubert"
+      ).build()
+    )
+
+    // inner joins
+    "support inner join" in {
+      val res3 = rel1.innerJoin(joinRel, (rec1, rec2) => rec1.get(colId) == rec2.get(colId))
+      res3.columns shouldEqual columnSet1 ++ columnSet2
+      res3.records shouldEqual Success(joinIdCommonResult)
+    }
+
+    "support inner equi join" in {
+      val res4 = rel1.innerEquiJoin(joinRel, (colId, colId))
+      res4.columns shouldEqual columnSet1 ++ columnSet2
+      res4.records shouldEqual Success(joinIdCommonResult)
+    }
+
+    // outer joins
+    "support full outer join" in {
+      val res5 = rel1.outerJoin(joinRel, (rec1, rec2) => rec1.get(colId) == rec2.get(colId))
+      res5.columns shouldEqual columnSet1 ++ columnSet2
+      res5.records shouldEqual Success(joinIdCommonResult ++ Seq(
+        joinRecordBuilder(
+          colId ~> 3 &
+            colFirstname ~> "Lisa"
+        ).build(),
+        joinRecordBuilder(
+          colId ~> 4 &
+            colLastname ~> "Gross"
+        ).build()
+      ))
+    }
+
+    "support left outer join" in {
+      val res6 = rel1.leftJoin(joinRel, (rec1, rec2) => rec1.get(colId) == rec2.get(colId))
+      res6.columns shouldEqual columnSet1 ++ columnSet2
+      res6.records shouldEqual Success(joinIdCommonResult ++ Seq(
+        joinRecordBuilder(
+          colId ~> 3 &
+            colFirstname ~> "Lisa"
+        ).build()
+      ))
+    }
+
+    "support right outer join" in {
+      val res7 = rel1.rightJoin(joinRel, (rec1, rec2) => rec1.get(colId) == rec2.get(colId))
+      res7.columns shouldEqual columnSet1 ++ columnSet2
+      res7.records shouldEqual Success(joinIdCommonResult ++ Seq(
+        joinRecordBuilder(
+          colId ~> 4 &
+            colLastname ~> "Gross"
+        ).build()
+      ))
+    }
+  }
+}

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOpsTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RelationBinOpsTest.scala
@@ -16,6 +16,7 @@ class RelationBinOpsTest extends WordSpec with Matchers {
   // result sets are equal if their order is not!
   implicit val sortedRecordSeqEquality: Equality[Try[Seq[Record]]] = new Equality[Try[Seq[Record]]] {
 
+    // define ordering without semantic meaning for comparison of Seq[Record] in test matchers
     implicit val recordOrdering: Ordering[Record] = (x: Record, y: Record) => x.hashCode() - y.hashCode()
 
     def areEqual(a: Try[Seq[Record]], b: Any): Boolean =

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -116,12 +116,12 @@ object Cart {
           .map( (rec: Record) => rec + (CartPurchases.sessionId -> currentSessionId))
           .map( (rec: Record) => CartPurchases.newRecord(
             CartPurchases.sectionId ~> rec.get(CartPurchases.sectionId).get &
-              CartPurchases.sessionId ~> rec.get(CartPurchases.sessionId).get &
-              CartPurchases.quantity ~> rec.get(CartPurchases.quantity).get &
-              CartPurchases.inventoryId ~> rec.get(StoreSection.Inventory.inventoryId).get &
-              CartPurchases.fixedDiscount ~> rec.get(GroupManager.Discounts.fixedDisc).get &
-              CartPurchases.minPrice ~> rec.get(StoreSection.Inventory.minPrice).get &
-              CartPurchases.price ~> rec.get(StoreSection.Inventory.price).get
+            CartPurchases.sessionId ~> rec.get(CartPurchases.sessionId).get &
+            CartPurchases.quantity ~> rec.get(CartPurchases.quantity).get &
+            CartPurchases.inventoryId ~> rec.get(StoreSection.Inventory.inventoryId).get &
+            CartPurchases.fixedDiscount ~> rec.get(GroupManager.Discounts.fixedDisc).get &
+            CartPurchases.minPrice ~> rec.get(StoreSection.Inventory.minPrice).get &
+            CartPurchases.price ~> rec.get(StoreSection.Inventory.price).get
           ).build())
       ))
       // FutureRelation: i_id, i_price, i_min_price, i_fixed_disc, sec_id, i_quantity, session_id

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -97,31 +97,32 @@ object Cart {
 
       val priceDisc: FutureRelation = priceList.innerJoin(fixedDiscount, (priceRec, discRec) =>
         priceRec.get(CartPurchases.inventoryId) == discRec.get(CartPurchases.inventoryId)
-      )
+      ).asInstanceOf[FutureRelation]
       // FutureRelation: i_id, i_price, i_min_price, fixed_disc
 
       val orderRecordBuilder = Record(Set(CartPurchases.inventoryId, CartPurchases.sectionId, CartPurchases.quantity))
-      val orderRelation = FutureRelation.fromRecordSeq(Future{orders.map(order => orderRecordBuilder(
+      val orderRelation: Relation = Relation(orders.map(order => orderRecordBuilder(
         CartPurchases.inventoryId ~> order.inventoryId &
         CartPurchases.sectionId ~> order.sectionId &
         CartPurchases.quantity ~> order.quantity
-      ).build())})
+      ).build()))
       val priceDiscOrder: FutureRelation = priceDisc.innerJoin(orderRelation, (priceRec, orderRec) =>
         priceRec.get(CartPurchases.inventoryId) == orderRec.get(CartPurchases.inventoryId)
-      )
+      ).asInstanceOf[FutureRelation]
       // FutureRelation: i_id, i_price, i_min_price, fixed_disc, sec_id, i_quantity
 
-      val result = FutureRelation.fromRecordSeq(priceDiscOrder.future.map(_.records.get
-        .map( (rec: Record) => rec + (CartPurchases.sessionId -> currentSessionId))
-        .map( (rec: Record) => CartPurchases.newRecord(
-          CartPurchases.sectionId ~> rec.get(CartPurchases.sectionId).get &
-          CartPurchases.sessionId ~> rec.get(CartPurchases.sessionId).get &
-          CartPurchases.quantity ~> rec.get(CartPurchases.quantity).get &
-          CartPurchases.inventoryId ~> rec.get(StoreSection.Inventory.inventoryId).get &
-          CartPurchases.fixedDiscount ~> rec.get(GroupManager.Discounts.fixedDisc).get &
-          CartPurchases.minPrice ~> rec.get(StoreSection.Inventory.minPrice).get &
-          CartPurchases.price ~> rec.get(StoreSection.Inventory.price).get
-        ).build())
+      val result: FutureRelation = priceDiscOrder.transform( relation => Relation(
+        relation.records.get
+          .map( (rec: Record) => rec + (CartPurchases.sessionId -> currentSessionId))
+          .map( (rec: Record) => CartPurchases.newRecord(
+            CartPurchases.sectionId ~> rec.get(CartPurchases.sectionId).get &
+              CartPurchases.sessionId ~> rec.get(CartPurchases.sessionId).get &
+              CartPurchases.quantity ~> rec.get(CartPurchases.quantity).get &
+              CartPurchases.inventoryId ~> rec.get(StoreSection.Inventory.inventoryId).get &
+              CartPurchases.fixedDiscount ~> rec.get(GroupManager.Discounts.fixedDisc).get &
+              CartPurchases.minPrice ~> rec.get(StoreSection.Inventory.minPrice).get &
+              CartPurchases.price ~> rec.get(StoreSection.Inventory.price).get
+          ).build())
       ))
       // FutureRelation: i_id, i_price, i_min_price, i_fixed_disc, sec_id, i_quantity, session_id
 


### PR DESCRIPTION
## Proposed Changes

  - Refactor handling of binary relation operations (like `join`, `union`)
  - Fix missing handling of combination of different `Relation` subtypes for those bin. operations
  - Test for those combinations.

## Imperfections

- binary operations on `FutureRelation` just return type `Relation`, to work with the future relation, one has to cast it back to `FutureRelation`:
  ```scala
  val priceList: FutureRelation = Dactor.askDactor(
    system,
    classOf[StoreSection],
    priceRequests)
  val priceDisc: FutureRelation = priceList.innerJoin(fixedDiscount,
    (priceRec, discRec) =>
      priceRec.get(CartPurchases.inventoryId) == discRec.get(CartPurchases.inventoryId)
  ).asInstanceOf[FutureRelation]
  priceDisc.pipeAsMessageTo(...)
  ```
- One has to change `RelationBinOps`, if there will be new descendants of `Relation` and provide a `<NewRelationType>.BinOps`-implementation for it
- matching on different `Relation` subtypes is done in `RelationBinOps` as well as in the `BinOps` objects of the implementing types 