### PR TITLE
Get rid of Option, when accessing record columns

### DIFF
--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/record/RecordTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/record/RecordTest.scala
@@ -1,5 +1,6 @@
 package de.up.hpi.informationsystems.adbms.record
 
+import de.up.hpi.informationsystems.adbms.IncompatibleColumnDefinitionException
 import de.up.hpi.informationsystems.adbms.definition.ColumnTypeDefaults._
 import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, ColumnTypeDefaults}
 import org.scalatest.{Matchers, WordSpec}
@@ -59,7 +60,7 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "not return any data" in {
-        emptyRecord.get(anyCol) shouldBe empty
+        a[IncompatibleColumnDefinitionException] should be thrownBy emptyRecord.get(anyCol)
       }
 
       "project to itself, when projected by an empty list" in {
@@ -83,10 +84,10 @@ class RecordTest extends WordSpec with Matchers {
       }
 
       "return default values, when accessing any column" in {
-        record.get(anyCol) shouldBe None
-        record.get(col1) shouldBe Some(ColumnTypeDefaults.value[String])
-        record.get(col2) shouldBe Some(ColumnTypeDefaults.value[Int])
-        record.get(col3) shouldBe Some(ColumnTypeDefaults.value[Double])
+        a[IncompatibleColumnDefinitionException] should be thrownBy record.get(anyCol)
+        record.get(col1) shouldBe ColumnTypeDefaults.value[String]
+        record.get(col2) shouldBe ColumnTypeDefaults.value[Int]
+        record.get(col3) shouldBe ColumnTypeDefaults.value[Double]
       }
 
       "project to empty record, when projected by an empty list" in {
@@ -118,18 +119,18 @@ class RecordTest extends WordSpec with Matchers {
         .build()
 
       "return the column's cell value" in {
-        record.get(anyCol) shouldBe None
-        record.get(col1) shouldBe Some(val1)
-        record.get(col2) shouldBe Some(val2)
-        record.get(col3) shouldBe Some(val3)
+        a[IncompatibleColumnDefinitionException] should be thrownBy record.get(anyCol)
+        record.get(col1) shouldBe val1
+        record.get(col2) shouldBe val2
+        record.get(col3) shouldBe val3
       }
 
       "retain values of projected columns and drop others" in {
         record.project(Set(col1)) match {
           case Success(r) =>
-            r.get(col1) shouldBe Some(val1)
-            r.get(col2) shouldBe None
-            r.get(col3) shouldBe None
+            r.get(col1) shouldBe val1
+            a[IncompatibleColumnDefinitionException] should be thrownBy r.get(col2)
+            a[IncompatibleColumnDefinitionException] should be thrownBy r.get(col3)
           case Failure(_) => fail("Projection by column sequence failed, but it should succeed")
         }
       }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/TransientRelationTest.scala
@@ -241,7 +241,7 @@ class TransientRelationTest extends WordSpec with Matchers {
 
       "return an appropriate result for innerJoin with itself using different column values" in {
         val diffColumnsJoined = fullRelation
-          .innerJoin(fullRelation, (lside, rside) => lside.get(colFirstname).get == rside.get(colLastname).get)
+          .innerJoin(fullRelation, (lside, rside) => lside.get(colFirstname) == rside.get(colLastname))
 
         diffColumnsJoined.columns shouldEqual columns
         diffColumnsJoined.records shouldEqual Success(Seq(record1))
@@ -249,7 +249,7 @@ class TransientRelationTest extends WordSpec with Matchers {
 
       "return itself for innerJoin with itself using the same column values" in {
         val sameColumnJoined = fullRelation
-          .innerJoin(fullRelation, (left, right) => left.get(colFirstname).get == right.get(colFirstname).get)
+          .innerJoin(fullRelation, (left, right) => left.get(colFirstname) == right.get(colFirstname))
 
         sameColumnJoined.columns shouldEqual columns
         sameColumnJoined.records shouldEqual Success(Seq(record1, record2))
@@ -284,10 +284,10 @@ class TransientRelationTest extends WordSpec with Matchers {
 
       "fail to innerJoin on wrong column definition" in {
         val joined1 = fullRelation
-          .innerJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")).get == right.get(colFirstname).get)
+          .innerJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")) == right.get(colFirstname))
           .records
         val joined2 = fullRelation
-          .innerJoin(fullRelation, (left, right) => left.get(colFirstname).get == right.get(ColumnDef[String]("something")).get)
+          .innerJoin(fullRelation, (left, right) => left.get(colFirstname) == right.get(ColumnDef[String]("something")))
           .records
 
         joined1.isFailure shouldBe true
@@ -335,10 +335,10 @@ class TransientRelationTest extends WordSpec with Matchers {
 
       "fail to outerJoin on wrong column definition" in {
         val joined1 = fullRelation
-          .outerJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")).get == right.get(colFirstname).get)
+          .outerJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")) == right.get(colFirstname))
           .records
         val joined2 = fullRelation
-          .outerJoin(fullRelation, (left, right) => left.get(colFirstname).get == right.get(ColumnDef[String]("something")).get)
+          .outerJoin(fullRelation, (left, right) => left.get(colFirstname) == right.get(ColumnDef[String]("something")))
           .records
 
         joined1.isFailure shouldBe true
@@ -381,10 +381,10 @@ class TransientRelationTest extends WordSpec with Matchers {
 
       "fail to leftJoin on wrong column definition" in {
         val joined1 = fullRelation
-          .leftJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")).get == right.get(colFirstname).get)
+          .leftJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")) == right.get(colFirstname))
           .records
         val joined2 = fullRelation
-          .leftJoin(fullRelation, (left, right) => left.get(colFirstname).get == right.get(ColumnDef[String]("something")).get)
+          .leftJoin(fullRelation, (left, right) => left.get(colFirstname) == right.get(ColumnDef[String]("something")))
           .records
 
         joined1.isFailure shouldBe true
@@ -427,10 +427,10 @@ class TransientRelationTest extends WordSpec with Matchers {
 
       "fail to rightJoin on wrong column definition" in {
         val joined1 = fullRelation
-          .rightJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")).get == right.get(colFirstname).get)
+          .rightJoin(fullRelation, (left, right) => left.get(ColumnDef[String]("something")) == right.get(colFirstname))
           .records
         val joined2 = fullRelation
-          .rightJoin(fullRelation, (left, right) => left.get(colFirstname).get == right.get(ColumnDef[String]("something")).get)
+          .rightJoin(fullRelation, (left, right) => left.get(colFirstname) == right.get(ColumnDef[String]("something")))
           .records
 
         joined1.isFailure shouldBe true


### PR DESCRIPTION
## Proposed Changes

  - changed signature from `Record#get[T](columnDef: ColumnDef[T]): Option[T]` to `Record#get[T](columnDef: ColumnDef[T]: T`
  - throwing an exception, when column is not part of record instead
  - adopted rest of code to comply to changes

## Is this reasonable??

## Map signatures:
For a `scala.immutable.Map[K,+V]` the signatures look like the following (defined in `MapLike[K, V, This]`):
- `apply(key: K): V` throws`NoSuchElementException` or returns the default value of the map
- `get(key: K): Option[V]` returns `Some(value)` or `None`