### PR TITLE
Use SingleRowRelation in sampleapp

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/DefaultMessageHandling.scala
@@ -43,9 +43,19 @@ trait DefaultMessageHandling extends Dactor {
     * @param records      records to be inserted
     * @return either number of successfully inserted records or a `Throwable` describing the failure
     */
-  private def handleGenericInsert(relationName: String, records: Seq[Record]): Try[Int] = Try {
-    relationFromName(relationName).insertAll(records).map(_.count(_ => true))
-  }.flatten
+  private def handleGenericInsert(relationName: String, records: Seq[Record]): Try[Int] =
+    if(records.length == 1)
+      records.headOption match {
+        case Some(record) =>
+          Try {
+            relationFromName(relationName).insert(record).map( _=> 1)
+          }.flatten
+        case None => Try(0)
+      }
+    else
+      Try {
+        relationFromName(relationName).insertAll(records).map(_.count(_ => true))
+      }.flatten
 
   /**
     * Returns an immutable copy of the requested relation if the `Dactor` has a `Relation` of this name,

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/record/Record.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/record/Record.scala
@@ -132,9 +132,12 @@ object Record {
   private[adbms] def fromMap(columnDefMap: Map[UntypedColumnDef, Any]): Record = new Record(columnDefMap)
 
   private[adbms] def fromVector(columnDefs: Vector[UntypedColumnDef])(data: Vector[Any]): Record =
-    new Record(columnDefs.indices.map{ index => columnDefs(index) -> data(index) }.toMap)
+      if(data.isEmpty)
+        Record.empty
+      else
+        new Record(columnDefs.indices.map{ index => columnDefs(index) -> data(index) }.toMap)
 
-  val empty: Record = Record.empty
+  val empty: Record = new Record(Map.empty)
 
   /**
     * Builder for a [[de.up.hpi.informationsystems.adbms.record.Record]].

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
@@ -1,5 +1,6 @@
 package de.up.hpi.informationsystems.adbms.relation
 
+import de.up.hpi.informationsystems.adbms.IncompatibleColumnDefinitionException
 import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, UntypedColumnDef}
 import de.up.hpi.informationsystems.adbms.record.{ColumnCellMapping, Record}
 
@@ -101,6 +102,36 @@ trait MutableRelation extends Relation {
   def immutable: Relation
 
   // helper
+
+  /**
+    * Checks incoming columns for being a subset of this relation's columns.
+    * Throws an exception, when it is not the case.
+    * @param incomingColumns columns passed to a function
+    * @throws IncompatibleColumnDefinitionException if `incomingColumns` is not a subset of `columns`
+    */
+  @throws[IncompatibleColumnDefinitionException]
+  protected def exceptionWhenNotSubset(incomingColumns: Iterable[UntypedColumnDef]): Unit =
+    if (!(incomingColumns.toSet subsetOf columns)) {
+      val notMatchingColumns = incomingColumns.toSet -- columns
+      throw IncompatibleColumnDefinitionException(s"this relation does not contain following columns: $notMatchingColumns")
+    }
+
+  /**
+    * Check incoming columns for being equal to this relation's columns.
+    * Throws an exception otherwise.
+    * @param incomingColumns columns passed to a function
+    * @throws IncompatibleColumnDefinitionException if `incomingColumns` is not equal to `columns`
+    */
+  @throws[IncompatibleColumnDefinitionException]
+  protected def exceptionWhenNotEqual(incomingColumns: Iterable[UntypedColumnDef]): Unit =
+    if(incomingColumns != columns)
+      throw IncompatibleColumnDefinitionException(
+        s"""the provided column layout does not match this relation's schema:
+           |$incomingColumns (provided)
+           |${this.columns} (relation)
+           |""".stripMargin
+      )
+
   /**
     * Helps building conditions for updating relations.
     *

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/MutableRelation.scala
@@ -1,5 +1,6 @@
 package de.up.hpi.informationsystems.adbms.relation
 
+import de.up.hpi.informationsystems.adbms.IncompatibleColumnDefinitionException
 import de.up.hpi.informationsystems.adbms.definition.ColumnDef
 import de.up.hpi.informationsystems.adbms.definition.ColumnDef.UntypedColumnDef
 import de.up.hpi.informationsystems.adbms.record.{ColumnCellMapping, Record}

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/RowRelation.scala
@@ -95,7 +95,7 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
   }
 
   /** @inheritdoc */
-  override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Relation = {
+  override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Relation =
     Relation(
       data.filter{ tuple =>
         fs.keys.map( col => {
@@ -104,7 +104,6 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
         }).forall(_ == true)
       }.toRecordSeq(cols)
     )
-  }
 
   /** @inheritdoc */
   override def project(columnDefs: Set[UntypedColumnDef]): Relation =
@@ -119,16 +118,16 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
 
   /** @inheritdoc */
   override def applyOn[T](col: ColumnDef[T], f: T => T): Relation =
-      if(!columns.contains(col))
-        this.immutable
-      else
-        Relation(Try{
-          val index = cols.indexOf(col)
-          data.map( tuple => {
-            val newValue = f(tuple(index).asInstanceOf[T])
-            tuple.updated(index, newValue)
-          }).toRecordSeq(cols)
-        })
+    if(!columns.contains(col))
+      this.immutable
+    else
+      Relation(Try{
+        val index = cols.indexOf(col)
+        data.map( tuple => {
+          val newValue = f(tuple(index).asInstanceOf[T])
+          tuple.updated(index, newValue)
+        }).toRecordSeq(cols)
+      })
 
   /** @inheritdoc */
   override def records: Try[Seq[Record]] = Try(data.toRecordSeq(cols))
@@ -138,18 +137,5 @@ private final class RowRelation(passedColumns: Set[UntypedColumnDef]) extends Mu
 
   /** @inheritdoc*/
   override def immutable: Relation = Relation(data.toRecordSeq(cols))
-
-  @throws[IncompatibleColumnDefinitionException]
-  private def exceptionWhenNotSubset(incomingColumns: Iterable[UntypedColumnDef]): Unit =
-    if (!(incomingColumns.toSet subsetOf columns)) {
-      val notMatchingColumns = incomingColumns.toSet -- columns
-      throw IncompatibleColumnDefinitionException(s"this relation does not contain following columns: $notMatchingColumns")
-    }
-
-  @throws[IncompatibleColumnDefinitionException]
-  private def exceptionWhenNotEqual(incomingColumns: Iterable[UntypedColumnDef]): Unit =
-    if(incomingColumns != columns)
-      throw IncompatibleColumnDefinitionException(s"the provided column layout does not match this " +
-        s"relation's schema:\n$incomingColumns (provided)\n${this.columns} (relation)")
 
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
@@ -59,6 +59,18 @@ class SingleRowRelation(pColumns: Set[UntypedColumnDef]) extends MutableRelation
     record
   }
 
+  /** This operation is not supported for `SingleRowRelation`s.
+    *
+    * Batch insert is only plausible if there are more than one record inserted.
+    * As a `SingleRowRelation` can only contain one record, `insert()` should be
+    * used instead.
+    *
+    * @return `Try[Seq[Record] ]` containing an [[UnsupportedOperationException]]
+    */
+  override def insertAll(records: Seq[Record]): Try[Seq[Record]] = Try{
+    throw new UnsupportedOperationException("A single row relation can only contain one row! Use `insert()` instead.")
+  }
+
   /** @inheritdoc */
   override def delete(record: Record): Try[Record] = Try{
     exceptionWhenNotEqual(record.columns)

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
@@ -1,9 +1,11 @@
 package de.up.hpi.informationsystems.adbms.relation
 
 import de.up.hpi.informationsystems.adbms.RecordNotFoundException
-import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef, UntypedColumnDef}
+import de.up.hpi.informationsystems.adbms.definition.ColumnDef.UntypedColumnDef
+import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef}
 import de.up.hpi.informationsystems.adbms.record.Record
 
+import scala.reflect.ClassTag
 import scala.util.Try
 
 object SingleRowRelation {
@@ -102,7 +104,7 @@ class SingleRowRelation(pColumns: Set[UntypedColumnDef]) extends MutableRelation
   // from Relation
 
   /** @inheritdoc */
-  override def where[T](f: (ColumnDef[T], T => Boolean)): Relation = {
+  override def where[T : ClassTag](f: (ColumnDef[T], T => Boolean)): Relation = {
     val (columnDef, condition) = f
     val index = cols.indexOf(columnDef) // -1 --> IndexOutOfBoundsException
 
@@ -133,7 +135,7 @@ class SingleRowRelation(pColumns: Set[UntypedColumnDef]) extends MutableRelation
   })
 
   /** @inheritdoc */
-  override def applyOn[T](col: ColumnDef[T], f: T => T): Relation = Relation(Try{
+  override def applyOn[T : ClassTag](col: ColumnDef[T], f: T => T): Relation = Relation(Try{
     exceptionWhenNotSubset(Seq(col))
     val index = cols.indexOf(col)
     val newValue = f(data(index).asInstanceOf[T])

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
@@ -1,0 +1,121 @@
+package de.up.hpi.informationsystems.adbms.relation
+
+import de.up.hpi.informationsystems.adbms.RecordNotFoundException
+import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef, UntypedColumnDef}
+import de.up.hpi.informationsystems.adbms.record.Record
+
+import scala.util.Try
+
+object SingleRowRelation {
+
+  /**
+    * Creates an instance of a single row relation, which actually stores data.
+    * Use a [[de.up.hpi.informationsystems.adbms.definition.RelationDef]] to define your relational schema.
+    * Use like the following:
+    *
+    * @example {{{
+    *           object MyRelation extends RelationDef {
+    *             ...
+    *           }
+    *           val myRelation: MutableRelation = SingleRowRelation(MyRelation)
+    * }}}
+    *
+    * @see [[de.up.hpi.informationsystems.adbms.definition.RelationDef]]
+    */
+  def apply(relDef: RelationDef): MutableRelation = new SingleRowRelation(relDef.columns)
+}
+
+class SingleRowRelation(pColumns: Set[UntypedColumnDef]) extends MutableRelation {
+  
+  private val cols: Vector[UntypedColumnDef] = pColumns.toVector
+  private var data: Vector[Any] = Vector.empty
+
+  /** @inheritdoc */
+  override val columns: Set[UntypedColumnDef] = pColumns
+
+  // from MutableRelation
+  /** @inheritdoc */
+  override def insert(record: Record): Try[Record] = Try{
+    exceptionWhenNotEqual(record.columns)
+    exceptionWhenAlreadyFull("insert")
+    data = cols.map( col => record(col) )
+    record
+  }
+
+  /** @inheritdoc */
+  override def delete(record: Record): Try[Record] = Try{
+    exceptionWhenNotEqual(record.columns)
+    val tuple = cols.map( col => record(col) )
+    if(data != tuple)
+      throw RecordNotFoundException(s"this relation does not contain $record")
+    data = Vector.empty
+    record
+  }
+
+  /** @inheritdoc */
+  override protected def internalUpdateByWhere(updateData: Map[UntypedColumnDef, Any], fs: Map[UntypedColumnDef, Any => Boolean]): Try[Int] = Try {
+    exceptionWhenNotSubset(updateData.keys)
+    val allFiltersApply = fs.keys
+      .map { col: UntypedColumnDef => fs(col)(data(cols.indexOf(col))) }
+      .forall(_ == true)
+
+    if(allFiltersApply){
+      data = updateData.keys.foldLeft(data)((t, updateCol) => t.updated(cols.indexOf(updateCol), updateData(updateCol)))
+      1
+    } else {
+      0
+    }
+  }
+
+  /** @inheritdoc */
+  override def immutable: Relation = Relation(Seq(Record.fromVector(cols)(data)))
+
+  // from Relation
+
+  /** @inheritdoc */
+  override def where[T](f: (ColumnDef[T], T => Boolean)): Relation = {
+    val (columnDef, condition) = f
+    val index = cols.indexOf(columnDef) // -1 --> IndexOutOfBoundsException
+
+    if(condition(data(index).asInstanceOf[T]))
+      this.immutable
+    else
+      Relation.empty
+  }
+
+  /** @inheritdoc */
+  override def whereAll(fs: Map[UntypedColumnDef, Any => Boolean]): Relation = {
+    val condResults = fs.keys.map( col => {
+      val index = cols.indexOf(col)
+      fs(col)(data(index))
+    })
+    if(condResults.forall(_ == true))
+      this.immutable
+    else
+      Relation.empty
+  }
+
+  /** @inheritdoc */
+  override def project(columnDefs: Set[UntypedColumnDef]): Relation = Relation(Try{
+    exceptionWhenNotSubset(columnDefs)
+    val newCols = columnDefs.toVector
+    val newTuple = newCols.map( colDef => data(cols.indexOf(colDef)))
+    Seq(Record.fromVector(newCols)(newTuple))
+  })
+
+  /** @inheritdoc */
+  override def applyOn[T](col: ColumnDef[T], f: T => T): Relation = Relation(Try{
+    exceptionWhenNotSubset(Seq(col))
+    val index = cols.indexOf(col)
+    val newValue = f(data(index).asInstanceOf[T])
+    Seq(Record.fromVector(cols)(data.updated(index, newValue)))
+  })
+
+  /** @inheritdoc */
+  override def records: Try[Seq[Record]] = Try(Seq(Record.fromVector(cols)(data)))
+
+  @throws[UnsupportedOperationException]
+  private def exceptionWhenAlreadyFull(op: String): Unit =
+    if(data.length == 1)
+      throw new UnsupportedOperationException(s"A single row relation can only contain one row! $op is not allowed anymore.")
+}

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelation.scala
@@ -88,7 +88,7 @@ class SingleRowRelation(pColumns: Set[UntypedColumnDef]) extends MutableRelation
     exceptionWhenNotSubset(updateData.keys)
     val allFiltersApply = fs.keys
       .map { col: UntypedColumnDef => fs(col)(data(cols.indexOf(col))) }
-      .forall(_ == true)
+      .forall(identity)
 
     if(allFiltersApply){
       data = updateData.keys.foldLeft(data)((t, updateCol) => t.updated(cols.indexOf(updateCol), updateData(updateCol)))
@@ -122,7 +122,7 @@ class SingleRowRelation(pColumns: Set[UntypedColumnDef]) extends MutableRelation
       val index = cols.indexOf(col)
       fs(col)(data(index))
     })
-    if(condResults.forall(_ == true))
+    if(condResults.forall(identity))
       data.toRecordSeq(cols)
     else
       Seq.empty

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RowRelationTest.scala
@@ -148,9 +148,12 @@ class RowRelationTest extends WordSpec with Matchers {
       val record2Delete = test.newRecord(Test.col1 ~> -1 & Test.col2 ~> "" & Test.col3 ~> "").build()
       val result = test.delete(record2Delete)
       result.isFailure shouldBe true
-      result.failed.get match {
-        case RecordNotFoundException(e) => e.contains("this relation does not contain the record") shouldBe true
-        case t => fail(s"the wrong exception was thrown\nexpected: RecordNotFoundExcpetion\nfound: $t")
+      result.failed match {
+        case Success(RecordNotFoundException(e)) =>
+          e.contains("this relation does not contain the record") shouldBe true
+        case Success(t) =>
+          fail(s"the wrong exception was thrown\nexpected: RecordNotFoundExcpetion\nfound: $t")
+        case _ => fail("unexpected match!")
       }
 
       test.records shouldBe Success(testRecords)
@@ -267,9 +270,12 @@ class RowRelationTest extends WordSpec with Matchers {
           .records
 
         result.isFailure shouldBe true
-        result.failed.get match {
-          case e: StringIndexOutOfBoundsException => e.getMessage.contains("String index out of range") shouldBe true
-          case t => fail(s"the wrong exception was thrown\nexpected: StringIndexOutOfBoundsException\nfound: $t")
+        result.failed match {
+          case Success(e: StringIndexOutOfBoundsException) =>
+            e.getMessage.contains("String index out of range") shouldBe true
+          case Success(t) =>
+            fail(s"the wrong exception was thrown\nexpected: StringIndexOutOfBoundsException\nfound: $t")
+          case _ => fail("unexpected match!")
         }
       }
 
@@ -296,7 +302,7 @@ class RowRelationTest extends WordSpec with Matchers {
       val customer = RowRelation(Customer)
       customer.insert(record1)
 
-      val result = customer.where(ColumnDef[Double]("WRONG") -> { d: Double => d == 2.1}).records
+      val result = customer.where(ColumnDef[Double]("WRONG") -> { d: Double => d == 2.1 }).records
 
       result.isFailure shouldBe true
     }
@@ -306,7 +312,7 @@ class RowRelationTest extends WordSpec with Matchers {
       customer.insert(record1)
 
       val result = customer.whereAll(
-        Map(ColumnDef[Double]("WRONG") -> ({ case d: Double => d == 2.1}: Any => Boolean))
+        Map(ColumnDef[Double]("WRONG") -> { case d: Double => d == 2.1 })
       ).records
 
       result.isFailure shouldBe true

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RowRelationTest.scala
@@ -62,7 +62,9 @@ class RowRelationTest extends WordSpec with Matchers {
     }
 
     "fail to insert records that do not adhere to the relations schema" in {
-      customer.insert(record4).isFailure should equal (true)
+      val test = RowRelation(Customer)
+      test.insert(record4).isFailure should equal (true)
+      test.records shouldEqual Success(Seq.empty)
     }
 
     "fail to batch insert records with at least one that does not adhere to the relations schema" in {

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/RowRelationTest.scala
@@ -208,6 +208,36 @@ class RowRelationTest extends WordSpec with Matchers {
         test.newRecord(col1 ~> 4 & col2 ~> "Firstname4" & col3 ~> "Lastname4").build()
       ))
     }
+    "fail on where query with wrong column definition" in {
+      val customer = RowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.where(ColumnDef[Double]("WRONG") -> { d: Double => d == 2.1}).records
+
+      result.isFailure shouldBe true
+    }
+
+    "fail on whereAll query with wrong column definition" in {
+      val customer = RowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.whereAll(
+        Map(ColumnDef[Double]("WRONG").untyped -> ({ case d: Double => d == 2.1}: Any => Boolean))
+      ).records
+
+      result.isFailure shouldBe true
+    }
+
+    "fail on project query with wrong column definition" in {
+      val customer = RowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.project(
+        Set(ColumnDef[Double]("WRONG").untyped)
+      ).records
+
+      result.isFailure shouldBe true
+    }
   }
 
   // queries on and joins with data from RowRelation are performed in TransientRelation and therefore tested in its test

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -145,5 +145,36 @@ class SingleRowRelationTest extends WordSpec with Matchers {
         Customer.newRecord(Customer.colAge ~> 42 & Customer.colFirstname ~> "Hans" & Customer.colLastname ~> "Maier").build()
       ))
     }
+
+    "fail on where query with wrong column definition" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.where(ColumnDef[Double]("WRONG") -> { d: Double => d == 2.1}).records
+
+      result.isFailure shouldBe true
+    }
+
+    "fail on whereAll query with wrong column definition" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.whereAll(
+        Map(ColumnDef[Double]("WRONG").untyped -> ({ case d: Double => d == 2.1}: Any => Boolean))
+      ).records
+
+      result.isFailure shouldBe true
+    }
+
+    "fail on project query with wrong column definition" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.project(
+        Set(ColumnDef[Double]("WRONG").untyped)
+      ).records
+
+      result.isFailure shouldBe true
+    }
   }
 }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -1,10 +1,11 @@
 package de.up.hpi.informationsystems.adbms.relation
 
-import de.up.hpi.informationsystems.adbms.{IncompatibleColumnDefinitionException, RecordNotFoundException}
+import de.up.hpi.informationsystems.adbms.definition.ColumnDef.UntypedColumnDef
 import de.up.hpi.informationsystems.adbms.definition.ColumnTypeDefaults._
-import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef, UntypedColumnDef}
+import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef}
 import de.up.hpi.informationsystems.adbms.record.ColumnCellMapping._
 import de.up.hpi.informationsystems.adbms.record.Record
+import de.up.hpi.informationsystems.adbms.{IncompatibleColumnDefinitionException, RecordNotFoundException}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Success
@@ -14,9 +15,9 @@ class SingleRowRelationTest extends WordSpec with Matchers {
   "A single row relation" should {
 
     object Customer extends RelationDef {
-      val colFirstname: ColumnDef[String] = ColumnDef("Firstname")
-      val colLastname: ColumnDef[String] = ColumnDef("Lastname")
-      val colAge: ColumnDef[Int] = ColumnDef("Age")
+      val colFirstname: ColumnDef[String] = ColumnDef[String]("Firstname")
+      val colLastname: ColumnDef[String] = ColumnDef[String]("Lastname")
+      val colAge: ColumnDef[Int] = ColumnDef[Int]("Age")
 
       override val columns: Set[UntypedColumnDef] = Set(colFirstname, colLastname, colAge)
       override val name: String = "customer"
@@ -136,8 +137,8 @@ class SingleRowRelationTest extends WordSpec with Matchers {
 
       val result = customer.update(Customer.colFirstname ~> "Hans" & Customer.colLastname ~> "Maier")
         .whereAll(
-          Map(Customer.colAge.untyped -> ({ case age: Int => age == 42 }: Any => Boolean)) ++
-          Map(Customer.colFirstname.untyped -> ({ case name: String => name == "Test" }: Any => Boolean))
+          Map(Customer.colAge -> ({ case age: Int => age == 42 }: Any => Boolean)) ++
+          Map(Customer.colFirstname -> ({ case name: String => name == "Test" }: Any => Boolean))
         )
       result shouldBe Success(1)
 
@@ -160,7 +161,7 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       customer.insert(record1)
 
       val result = customer.whereAll(
-        Map(ColumnDef[Double]("WRONG").untyped -> ({ case d: Double => d == 2.1}: Any => Boolean))
+        Map(ColumnDef[Double]("WRONG") -> { case d: Double => d == 2.1 })
       ).records
 
       result.isFailure shouldBe true
@@ -171,7 +172,7 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       customer.insert(record1)
 
       val result = customer.project(
-        Set(ColumnDef[Double]("WRONG").untyped)
+        Set(ColumnDef[Double]("WRONG"))
       ).records
 
       result.isFailure shouldBe true

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -184,5 +184,19 @@ class SingleRowRelationTest extends WordSpec with Matchers {
 
       result.isFailure shouldBe true
     }
+
+    "return empty result on all unary operations when empty" in {
+      val customer = SingleRowRelation(Customer)
+
+      val result1 = customer.project(Set(Customer.colFirstname)).records
+      val result2 = customer.where(Customer.colFirstname -> { s: String => s == "" }).records
+      val result3 = customer.whereAll(Map(Customer.colFirstname -> { case s: String => s == "" })).records
+      val result4 = customer.applyOn(Customer.colFirstname, { s: String => s"$s test" }).records
+
+      result1 shouldEqual Success(Seq.empty)
+      result2 shouldEqual Success(Seq.empty)
+      result3 shouldEqual Success(Seq.empty)
+      result4 shouldEqual Success(Seq.empty)
+    }
   }
 }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -101,7 +101,7 @@ class SingleRowRelationTest extends WordSpec with Matchers {
 
       result.isFailure shouldBe true
       result.failed.get match {
-        case RecordNotFoundException(e) => e.contains("this relation does not contain the record") shouldBe true
+        case RecordNotFoundException(e) => e.contains("this relation does not contain") shouldBe true
         case t => fail(s"the wrong exception was thrown\nexpected: RecordNotFoundExcpetion\nfound: $t")
       }
       customer.records shouldBe Success(Seq(record1))

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -1,0 +1,149 @@
+package de.up.hpi.informationsystems.adbms.relation
+
+import de.up.hpi.informationsystems.adbms.{IncompatibleColumnDefinitionException, RecordNotFoundException}
+import de.up.hpi.informationsystems.adbms.definition.ColumnTypeDefaults._
+import de.up.hpi.informationsystems.adbms.definition.{ColumnDef, RelationDef, UntypedColumnDef}
+import de.up.hpi.informationsystems.adbms.record.ColumnCellMapping._
+import de.up.hpi.informationsystems.adbms.record.Record
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.Success
+
+class SingleRowRelationTest extends WordSpec with Matchers {
+
+  "A single row relation" should {
+
+    object Customer extends RelationDef {
+      val colFirstname: ColumnDef[String] = ColumnDef("Firstname")
+      val colLastname: ColumnDef[String] = ColumnDef("Lastname")
+      val colAge: ColumnDef[Int] = ColumnDef("Age")
+
+      override val columns: Set[UntypedColumnDef] = Set(colFirstname, colLastname, colAge)
+      override val name: String = "customer"
+    }
+    val record1 = Record(Customer.columns)
+      .withCellContent(Customer.colFirstname)("Test")
+      .withCellContent(Customer.colLastname)("Test")
+      .withCellContent(Customer.colAge)(42)
+      .build()
+
+    val record2 = Record(Customer.columns)
+      // missing firstName
+      .withCellContent(Customer.colLastname)("Doe")
+      .withCellContent(Customer.colAge)(200215)
+      .build()
+
+    val record3 = Record(Set(ColumnDef[String]("ID"), ColumnDef[Int]("LEVEL"))) // wrong record type
+      .withCellContent(Customer.colLastname)("A8102C2")
+      .withCellContent(Customer.colAge)(3)
+      .build()
+
+    "insert records without missing values correctly" in {
+      val customer = SingleRowRelation(Customer)
+      val inserted = customer.insert(record1)
+
+      inserted shouldEqual Success(record1)
+      customer.records shouldEqual Success(Seq(record1))
+    }
+
+    "insert records with missing values correctly" in {
+      val customer = SingleRowRelation(Customer)
+      val inserted = customer.insert(record2)
+
+      inserted shouldEqual Success(record2)
+      customer.records shouldEqual Success(Seq(record2))
+    }
+
+    "not allow inserting records with wrong columns" in {
+      val customer = SingleRowRelation(Customer)
+      val inserted = customer.insert(record3)
+
+      inserted.isFailure shouldBe true
+      inserted.failed.get match {
+        case e: IncompatibleColumnDefinitionException =>
+          e.getMessage.contains("the provided column layout does not match this relation's schema") shouldBe true
+        case t => fail(s"the wrong exception was thrown\nexpected: IncompatibleColumnDefinitionException\nfound: $t")
+      }
+      customer.records shouldEqual Success(Seq.empty)
+    }
+
+    "not allow batch insert of records" in {
+      val customer = SingleRowRelation(Customer)
+      val inserted = customer.insertAll(Seq(record1, record2))
+
+      inserted.isFailure shouldBe true
+      inserted.failed.get match {
+        case e: UnsupportedOperationException =>
+          e.getMessage.contains("A single row relation can only contain one row!") shouldBe true
+        case t => fail(s"the wrong exception was thrown\nexpected: UnsupportedOperationException\nfound: $t")
+      }
+      customer.records shouldEqual Success(Seq.empty)
+    }
+
+    "fail to insert records that do not adhere to the relations schema" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record3).isFailure shouldBe true
+    }
+
+    "allow deletion of records" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+      val result = customer.delete(record1)
+
+      result shouldEqual Success(record1)
+      customer.records shouldEqual Success(Seq.empty)
+    }
+
+    "throw error when trying to delete non-existing record" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+      val result = customer.delete(record2)
+
+      result.isFailure shouldBe true
+      result.failed.get match {
+        case RecordNotFoundException(e) => e.contains("this relation does not contain the record") shouldBe true
+        case t => fail(s"the wrong exception was thrown\nexpected: RecordNotFoundExcpetion\nfound: $t")
+      }
+      customer.records shouldBe Success(Seq(record1))
+    }
+
+    "allow inserting a new record after deletion" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+      customer.delete(record1)
+      val result = customer.insert(record2)
+
+      result shouldEqual Success(record2)
+      customer.records shouldEqual Success(Seq(record2))
+    }
+
+    "allow updating the record with simple where" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.update(Customer.colFirstname ~> "Hans" & Customer.colLastname ~> "Maier")
+        .where[Int](Customer.colAge -> { _ == 42 })
+      result shouldBe Success(1)
+
+      customer.records shouldBe Success(Seq(
+        Customer.newRecord(Customer.colAge ~> 42 & Customer.colFirstname ~> "Hans" & Customer.colLastname ~> "Maier").build()
+      ))
+    }
+
+    "allow updating the record with multiple where conditions" in {
+      val customer = SingleRowRelation(Customer)
+      customer.insert(record1)
+
+      val result = customer.update(Customer.colFirstname ~> "Hans" & Customer.colLastname ~> "Maier")
+        .whereAll(
+          Map(Customer.colAge.untyped -> ({ case age: Int => age == 42 }: Any => Boolean)) ++
+          Map(Customer.colFirstname.untyped -> ({ case name: String => name == "Test" }: Any => Boolean))
+        )
+      result shouldBe Success(1)
+
+      customer.records shouldBe Success(Seq(
+        Customer.newRecord(Customer.colAge ~> 42 & Customer.colFirstname ~> "Hans" & Customer.colLastname ~> "Maier").build()
+      ))
+    }
+  }
+}

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -63,7 +63,8 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       inserted.failed match {
         case Success(e: IncompatibleColumnDefinitionException) =>
           e.getMessage.contains("the provided column layout does not match this relation's schema") shouldBe true
-        case Success(t) => fail(s"the wrong exception was thrown\nexpected: IncompatibleColumnDefinitionException\nfound: $t")
+        case Success(t) =>
+          fail(s"the wrong exception was thrown\nexpected: IncompatibleColumnDefinitionException\nfound: $t")
         case _ => fail("unexpected match!")
       }
       customer.records shouldEqual Success(Seq.empty)
@@ -77,7 +78,8 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       inserted.failed match {
         case Success(e: UnsupportedOperationException) =>
           e.getMessage.contains("A single row relation can only contain one row!") shouldBe true
-        case Success(t) => fail(s"the wrong exception was thrown\nexpected: UnsupportedOperationException\nfound: $t")
+        case Success(t) =>
+          fail(s"the wrong exception was thrown\nexpected: UnsupportedOperationException\nfound: $t")
         case _ => fail("unexpected match!")
       }
       customer.records shouldEqual Success(Seq.empty)
@@ -103,9 +105,12 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       val result = customer.delete(record2)
 
       result.isFailure shouldBe true
-      result.failed.get match {
-        case RecordNotFoundException(e) => e.contains("this relation does not contain") shouldBe true
-        case t => fail(s"the wrong exception was thrown\nexpected: RecordNotFoundExcpetion\nfound: $t")
+      result.failed match {
+        case Success(RecordNotFoundException(e)) =>
+          e.contains("this relation does not contain") shouldBe true
+        case Success(t) =>
+          fail(s"the wrong exception was thrown\nexpected: RecordNotFoundExcpetion\nfound: $t")
+        case _ => fail("unexpected match!")
       }
       customer.records shouldBe Success(Seq(record1))
     }

--- a/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
+++ b/adbms/src/test/scala/de/up/hpi/informationsystems/adbms/relation/SingleRowRelationTest.scala
@@ -60,10 +60,11 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       val inserted = customer.insert(record3)
 
       inserted.isFailure shouldBe true
-      inserted.failed.get match {
-        case e: IncompatibleColumnDefinitionException =>
+      inserted.failed match {
+        case Success(e: IncompatibleColumnDefinitionException) =>
           e.getMessage.contains("the provided column layout does not match this relation's schema") shouldBe true
-        case t => fail(s"the wrong exception was thrown\nexpected: IncompatibleColumnDefinitionException\nfound: $t")
+        case Success(t) => fail(s"the wrong exception was thrown\nexpected: IncompatibleColumnDefinitionException\nfound: $t")
+        case _ => fail("unexpected match!")
       }
       customer.records shouldEqual Success(Seq.empty)
     }
@@ -73,10 +74,11 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       val inserted = customer.insertAll(Seq(record1, record2))
 
       inserted.isFailure shouldBe true
-      inserted.failed.get match {
-        case e: UnsupportedOperationException =>
+      inserted.failed match {
+        case Success(e: UnsupportedOperationException) =>
           e.getMessage.contains("A single row relation can only contain one row!") shouldBe true
-        case t => fail(s"the wrong exception was thrown\nexpected: UnsupportedOperationException\nfound: $t")
+        case Success(t) => fail(s"the wrong exception was thrown\nexpected: UnsupportedOperationException\nfound: $t")
+        case _ => fail("unexpected match!")
       }
       customer.records shouldEqual Success(Seq.empty)
     }
@@ -151,7 +153,7 @@ class SingleRowRelationTest extends WordSpec with Matchers {
       val customer = SingleRowRelation(Customer)
       customer.insert(record1)
 
-      val result = customer.where(ColumnDef[Double]("WRONG") -> { d: Double => d == 2.1}).records
+      val result = customer.where(ColumnDef[Double]("WRONG") -> { d: Double => d == 2.1 }).records
 
       result.isFailure shouldBe true
     }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -11,7 +11,7 @@ import de.up.hpi.informationsystems.adbms.definition._
 import de.up.hpi.informationsystems.adbms.protocols.{DefaultMessageHandling, RequestResponseProtocol}
 import de.up.hpi.informationsystems.adbms.record.ColumnCellMapping._
 import de.up.hpi.informationsystems.adbms.record.Record
-import de.up.hpi.informationsystems.adbms.relation.{FutureRelation, MutableRelation, Relation}
+import de.up.hpi.informationsystems.adbms.relation._
 import de.up.hpi.informationsystems.sampleapp.DataInitializer
 import de.up.hpi.informationsystems.sampleapp.dactors.Cart.CartBase
 
@@ -187,7 +187,8 @@ object Cart {
     private val helper: CartHelper = CartHelper(context.system, self, timeout)
 
     override protected val relations: Map[RelationDef, MutableRelation] =
-      Dactor.createAsRowRelations(Seq(CartInfo, CartPurchases))
+      Map(CartInfo -> SingleRowRelation(CartInfo)) ++
+      Map(CartPurchases -> RowRelation(CartPurchases))
 
     private var currentSessionId = 0
 


### PR DESCRIPTION
## Proposed Changes

  - `Cart` and `Customer` now use `SingleRowRelation` for their details
  - `DefaultMessageHandling` now uses `insert` for input only containing one row
  - found issue with indices in empty `SingleRowRelation`s and fixed it ( + tests)

## Related

  - PR #103 (**merge first**)
  - Issue #64
