### PR TITLE
Change RequestResponseProtocol to use a Message type parameter in anticipation of Functions

### DIFF
--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -83,7 +83,9 @@ object Dactor {
     * @return             a FutureRelation of the unioned results from the Requests on successful completion
     */
   def askDactor(
-                system: ActorSystem, dactorClass: Class[_ <: Dactor], messages: Map[Int, RequestResponseProtocol.Request]
+                system: ActorSystem,
+                dactorClass: Class[_ <: Dactor],
+                messages: Map[Int, RequestResponseProtocol.Request[_ <: RequestResponseProtocol.Message]]
                )(
                 implicit timeout: Timeout
                ): FutureRelation = {
@@ -95,10 +97,10 @@ object Dactor {
         val answer: Future[Any] = akka.pattern.ask(dactorSelection(system, dactorClass, dactorId), msg)(timeout)
         // FIXME: match on result and handle success / failure differences!!!!
         answer
-          .mapTo[RequestResponseProtocol.Response]
+          .mapTo[RequestResponseProtocol.Response[_]]
           .map{
-            case s: RequestResponseProtocol.Success => scala.util.Success(s.result)
-            case f: RequestResponseProtocol.Failure => scala.util.Failure(f.e)
+            case s: RequestResponseProtocol.Success[_] => scala.util.Success(s.result)
+            case f: RequestResponseProtocol.Failure[_] => scala.util.Failure(f.e)
           }
           .map(_.get)
       })

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/Dactor.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSelectio
 import akka.util.Timeout
 import de.up.hpi.informationsystems.adbms.definition._
 import de.up.hpi.informationsystems.adbms.protocols.RequestResponseProtocol
-import de.up.hpi.informationsystems.adbms.relation.{FutureRelation, MutableRelation, Relation, RowRelation}
+import de.up.hpi.informationsystems.adbms.relation.{FutureRelation, MutableRelation, RowRelation}
 
 import scala.concurrent.Future
 

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
@@ -6,6 +6,33 @@ object RequestResponseProtocol {
 
   /** Message type to be subclassed and used as [[Request]] and [[Response]] type information
     *
+    * Subclasses of this marker trait are used as type parameters for [[Request]], [[Success]], and [[Failure]]
+    * subclasses. The marker trait then allows for specific pattern matching on [[Request]] and [[Response]] subtypes.
+    *
+    * @example{{{
+    *           // Request and response message definitions in some Dactors companion object implementation:
+    *           object MyMessage {
+    *             sealed trait MyMessage extends Message
+    *             case class Request(someParam: SomeType) extends RequestResponseProtocol.Request[MyMessage]
+    *             case class Success(result: Relation) extends RequestResponseProtocol.Success[MyMessage]
+    *             case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[MyMessage]
+    *           }
+    *
+    *           object OtherMessage {
+    *             sealed trait OtherMessage extends Message
+    *             case class Request(someParam: SomeType) extends RequestResponseProtocol.Request[OtherMessage]
+    *             case class Success(result: Relation) extends RequestResponseProtocol.Success[OtherMessage]
+    *             case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[OtherMessage]
+    *           }
+    *
+    *           // Receive function of same Dactor reacting to [[Success]] messages of different types:
+    *           override def receive: Receive = {
+    *             case message: MyMessage.Success => // do something with this relation
+    *             case message: OtherMessage.Success => // do something else with that relation
+    *             case message: RequestResponseProtocol.Failure[_] => // match on the superclass to have common behavior
+    *               log.error(message.e.getMessage)
+    *           }
+    * }}}
     */
   trait Message
 

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
@@ -4,28 +4,35 @@ import de.up.hpi.informationsystems.adbms.relation.Relation
 
 object RequestResponseProtocol {
 
+  /**
+    *
+    */
+  trait Message
+
   /** A Request to a Dactor for which you expect a Response.
     *
     * Each Dactor that can reply to queries subclasses these traits with their own message types so one can match on
     * expected message types
     */
-  trait Request
+  trait Request[+T <: Message]
 
-  sealed trait Response
+  sealed trait Response[+T <: Message]
 
   /** A successful Response from a Dactor in answer to a Request.
     *
+    * @tparam T [[RequestResponseProtocol.Message]] subtype to which this success response belongs
     * @see[[de.up.hpi.informationsystems.adbms.protocols.RequestResponseProtocol.Response]]
     */
-  trait Success extends Response {
+  trait Success[+T <: Message] extends Response[T] {
     def result: Relation
   }
 
   /** A failure Response that is used to inform about some failure during answering to a Request.
     *
+    * @tparam T [[RequestResponseProtocol.Message]] subtype to which this failure response belongs
     * @see[[de.up.hpi.informationsystems.adbms.protocols.RequestResponseProtocol.Response]]
     */
-  trait Failure extends Response {
+  trait Failure[+T <: Message] extends Response[T] {
     def e: Throwable
   }
 }

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
@@ -4,7 +4,7 @@ import de.up.hpi.informationsystems.adbms.relation.Relation
 
 object RequestResponseProtocol {
 
-  /** Message type to be subclassed and used as [[Request]] and [[Response]] type information
+  /** Marker trait to be subclassed and used with [[Request]], [[Success]], and [[Failure]] as message type information.
     *
     * Subclasses of this marker trait are used as type parameters for [[Request]], [[Success]], and [[Failure]]
     * subclasses. The marker trait then allows for specific pattern matching on [[Request]] and [[Response]] subtypes.

--- a/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
+++ b/adbms/src/main/scala/de/up/hpi/informationsystems/adbms/protocols/RequestResponseProtocol.scala
@@ -4,18 +4,27 @@ import de.up.hpi.informationsystems.adbms.relation.Relation
 
 object RequestResponseProtocol {
 
-  /**
+  /** Message type to be subclassed and used as [[Request]] and [[Response]] type information
     *
     */
   trait Message
 
   /** A Request to a Dactor for which you expect a Response.
     *
-    * Each Dactor that can reply to queries subclasses these traits with their own message types so one can match on
-    * expected message types
+    * Each Dactor that can reply to queries or Functions subclasses these traits with their own message types so one can
+    * match on expected message types
+    *
+    * @tparam T [[RequestResponseProtocol.Message]] subtype defining the message type of this request
     */
   trait Request[+T <: Message]
 
+  /** A Response from a Dactor, sent in response to a [[Request]].
+    *
+    * Each Dactor that can reply to queries or Functions subclasses these traits with their own message types so one can
+    * match on expected message types.
+    *
+    * @tparam T [[RequestResponseProtocol.Message]] subtype defining the message type of this response
+    */
   sealed trait Response[+T <: Message]
 
   /** A successful Response from a Dactor in answer to a Request.

--- a/fouleggs/src/de/up/hpi/informationsystems/fouleggs/dactors/AdminSession.scala
+++ b/fouleggs/src/de/up/hpi/informationsystems/fouleggs/dactors/AdminSession.scala
@@ -13,9 +13,10 @@ object AdminSession {
   final case object Up
 
   object AddCastToFilm {
-    final case class Request(personId: Int, filmId: Int, roleName: String) extends RequestResponseProtocol.Request
-    final case class Success(result: Relation) extends RequestResponseProtocol.Success
-    final case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    sealed trait AddCastToFilm extends RequestResponseProtocol.Message
+    final case class Request(personId: Int, filmId: Int, roleName: String) extends RequestResponseProtocol.Request[AddCastToFilm]
+    final case class Success(result: Relation) extends RequestResponseProtocol.Success[AddCastToFilm]
+    final case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[AddCastToFilm]
   }
 
   def props: Props = Props[AdminSession]

--- a/fouleggs/src/de/up/hpi/informationsystems/fouleggs/dactors/AdminSession.scala
+++ b/fouleggs/src/de/up/hpi/informationsystems/fouleggs/dactors/AdminSession.scala
@@ -2,7 +2,7 @@ package de.up.hpi.informationsystems.fouleggs.dactors
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import de.up.hpi.informationsystems.adbms.Dactor
-import de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol
+import de.up.hpi.informationsystems.adbms.protocols.DefaultMessagingProtocol.{SelectAllFromRelation, InsertIntoRelation}
 import de.up.hpi.informationsystems.adbms.record.Record
 import de.up.hpi.informationsystems.adbms.record.ColumnCellMapping._
 import de.up.hpi.informationsystems.adbms.relation.Relation
@@ -32,7 +32,7 @@ class AdminSession extends Actor with ActorLogging {
     case AdminSession.Up => sender() ! akka.actor.Status.Success
     case AdminSession.AddCastToFilm.Request(personId, filmId, roleName) =>
       addCastToFilm(personId, filmId, roleName)
-    case DefaultMessagingProtocol.SelectAllFromRelation.Success(rel) => log.info(rel.toString)
+    case SelectAllFromRelation.Success(rel) => log.info(rel.toString)
   }
 
   def addCastToFilm(personId: Int, filmId: Int, roleName: String): Unit = {
@@ -49,8 +49,8 @@ class AdminSession extends Actor with ActorLogging {
       val empire = Dactor.dactorSelection(context.system, classOf[Film], 1)
       val mark = Dactor.dactorSelection(context.system, classOf[Person], 1)
 
-      empire ! DefaultMessagingProtocol.SelectAllFromRelation.Request(Film.Cast.name)
-      mark ! DefaultMessagingProtocol.SelectAllFromRelation.Request(Person.Filmography.name)
+      empire ! SelectAllFromRelation.Request(Film.Cast.name)
+      mark ! SelectAllFromRelation.Request(Person.Filmography.name)
     }
   }
 }
@@ -93,11 +93,11 @@ class AddFilmFunctor(personId: Int, filmId: Int, roleName: String, backTo: Actor
 
   override def receive: Receive = waitingForFilmInfo orElse commonBehaviour
 
-  Dactor.dactorSelection(context.system, classOf[Film], filmId) ! DefaultMessagingProtocol.SelectAllFromRelation.Request("film_info")
+  Dactor.dactorSelection(context.system, classOf[Film], filmId) ! SelectAllFromRelation.Request("film_info")
 
   def waitingForFilmInfo: Receive = {
-    case DefaultMessagingProtocol.SelectAllFromRelation.Failure(e) => fail(e)
-    case DefaultMessagingProtocol.SelectAllFromRelation.Success(relation: Relation) =>
+    case SelectAllFromRelation.Failure(e) => fail(e)
+    case SelectAllFromRelation.Success(relation: Relation) =>
       val filmInfoOption: Option[Record] = relation.records.toOption match {
         case Some(records: Seq[Record]) => records.headOption
         case _ => None
@@ -112,7 +112,7 @@ class AddFilmFunctor(personId: Int, filmId: Int, roleName: String, backTo: Actor
             Person.Filmography.filmName ~> filmInfo(Film.Info.title) &
             Person.Filmography.filmRelease ~> filmInfo(Film.Info.release)
         ).build()
-        Dactor.dactorSelection(context.system, classOf[Person], personId) ! DefaultMessagingProtocol.InsertIntoRelation("filmography", Seq(newFilmRecord))
+        Dactor.dactorSelection(context.system, classOf[Person], personId) ! InsertIntoRelation("filmography", Seq(newFilmRecord))
         context.become(waitingForInsertAck orElse commonBehaviour)
     }
   }
@@ -143,11 +143,11 @@ class AddCastFunctor(personId: Int, filmId: Int, roleName: String, backTo: Actor
   override def receive: Receive = waitingForPersonInfo orElse commonBehaviour
 
   // very first message has to be sent outside of Receives
-  Dactor.dactorSelection(context.system, classOf[Person], personId) ! DefaultMessagingProtocol.SelectAllFromRelation.Request("person_info")
+  Dactor.dactorSelection(context.system, classOf[Person], personId) ! SelectAllFromRelation.Request("person_info")
 
   def waitingForPersonInfo: Receive = {
-    case DefaultMessagingProtocol.SelectAllFromRelation.Failure(e) => fail(e)
-    case DefaultMessagingProtocol.SelectAllFromRelation.Success(relation: Relation) => {
+    case SelectAllFromRelation.Failure(e) => fail(e)
+    case SelectAllFromRelation.Success(relation: Relation) => {
       val personInfoOption: Option[Record] = relation.records.toOption match {
         case Some(records: Seq[Record]) => records.headOption
         case _ => None
@@ -162,7 +162,7 @@ class AddCastFunctor(personId: Int, filmId: Int, roleName: String, backTo: Actor
               Film.Cast.roleName ~> roleName &
               Film.Cast.personId ~> personId
           ).build()
-          Dactor.dactorSelection(context.system, classOf[Film], filmId) ! DefaultMessagingProtocol.InsertIntoRelation("film_cast", Seq(newCastRecord))
+          Dactor.dactorSelection(context.system, classOf[Film], filmId) ! InsertIntoRelation("film_cast", Seq(newCastRecord))
           context.become(waitingForInsertAck orElse commonBehaviour)
       }
     }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/Main.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/Main.scala
@@ -17,11 +17,9 @@ object Main extends App {
   println("Starting system")
   SystemInitializer.initializer ! SystemInitializer.Startup(5 seconds)
 
-  Runtime.getRuntime.addShutdownHook(new Thread() {
-    override def run(): Unit = {
-      println(s"Received shutdown signal from JVM")
-      SystemInitializer.initializer ! SystemInitializer.Shutdown
-    }
+  sys.addShutdownHook({
+    println(s"Received shutdown signal from JVM")
+    SystemInitializer.initializer ! SystemInitializer.Shutdown
   })
 
 }

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Cart.scala
@@ -25,16 +25,18 @@ object Cart {
   object AddItems {
     case class Order(inventoryId: Int, sectionId: Int, quantity: Int)
 
+    sealed trait AddItems extends RequestResponseProtocol.Message
     // orders: item_id, i_quantity
-    case class Request(orders: Seq[Order], customerId: Int) extends RequestResponseProtocol.Request
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    case class Request(orders: Seq[Order], customerId: Int) extends RequestResponseProtocol.Request[AddItems]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[AddItems]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[AddItems]
   }
 
   object Checkout {
-    case class Request(sessionId: Int) extends RequestResponseProtocol.Request
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    sealed trait Checkout extends RequestResponseProtocol.Message
+    case class Request(sessionId: Int) extends RequestResponseProtocol.Request[Checkout]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[Checkout]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[Checkout]
   }
 
   object CartInfo extends RelationDef {

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -21,34 +21,34 @@ object Customer {
   def props(id: Int): Props = Props(new Customer(id))
 
   object GetCustomerInfo {
-
-    case class Request() extends RequestResponseProtocol.Request
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    sealed trait GetCustomerInfo extends RequestResponseProtocol.Message
+    case class Request() extends RequestResponseProtocol.Request[GetCustomerInfo]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetCustomerInfo]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetCustomerInfo]
 
   }
 
   object GetCustomerGroupId {
-
-    case class Request() extends RequestResponseProtocol.Request
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    sealed trait GetCustomerInfo extends RequestResponseProtocol.Message
+    case class Request() extends RequestResponseProtocol.Request[GetCustomerInfo]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetCustomerInfo]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetCustomerInfo]
 
   }
 
   object AddStoreVisit {
-
-    case class Request(storeId: Int, time: ZonedDateTime, amount: Double, fixedDiscount: Double, varDiscount: Double) extends RequestResponseProtocol.Request
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    sealed trait AddStoreVisit extends RequestResponseProtocol.Message
+    case class Request(storeId: Int, time: ZonedDateTime, amount: Double, fixedDiscount: Double, varDiscount: Double) extends RequestResponseProtocol.Request[AddStoreVisit]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[AddStoreVisit]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[AddStoreVisit]
 
   }
 
   object Authenticate {
-
-    case class Request(passwordHash: String) extends RequestResponseProtocol.Request
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    sealed trait Authenticate extends RequestResponseProtocol.Message
+    case class Request(passwordHash: String) extends RequestResponseProtocol.Request[Authenticate]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[Authenticate]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[Authenticate]
 
   }
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/Customer.scala
@@ -29,10 +29,10 @@ object Customer {
   }
 
   object GetCustomerGroupId {
-    sealed trait GetCustomerInfo extends RequestResponseProtocol.Message
-    case class Request() extends RequestResponseProtocol.Request[GetCustomerInfo]
-    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetCustomerInfo]
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetCustomerInfo]
+    sealed trait GetCustomerGroupId extends RequestResponseProtocol.Message
+    case class Request() extends RequestResponseProtocol.Request[GetCustomerGroupId]
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetCustomerGroupId]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetCustomerGroupId]
 
   }
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/GroupManager.scala
@@ -17,11 +17,11 @@ object GroupManager {
   def props(id: Int): Props = Props(new GroupManager(id))
 
   object GetFixedDiscounts {
-
-    case class Request(ids: Seq[Int]) extends RequestResponseProtocol.Request
+    sealed trait GetFixedDiscounts extends RequestResponseProtocol.Message
+    case class Request(ids: Seq[Int]) extends RequestResponseProtocol.Request[GetFixedDiscounts]
     // results: i_id, fixed_disc
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetFixedDiscounts]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetFixedDiscounts]
 
   }
 

--- a/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
+++ b/sampleapp/src/main/scala/de/up/hpi/informationsystems/sampleapp/dactors/StoreSection.scala
@@ -21,11 +21,11 @@ object StoreSection {
   def props(id: Int): Props = Props(new StoreSection(id))
 
   object GetPrice {
-
-    case class Request(inventoryIds: Seq[Int]) extends RequestResponseProtocol.Request
+    sealed trait GetPrice extends RequestResponseProtocol.Message
+    case class Request(inventoryIds: Seq[Int]) extends RequestResponseProtocol.Request[GetPrice]
     // result: i_id, i_price, i_min_price
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetPrice]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetPrice]
 
   }
 
@@ -34,11 +34,12 @@ object StoreSection {
     val fixedDiscCol: ColumnDef[Double] = ColumnDef[Double]("fixed_disc")
     val varDiscCol: ColumnDef[Double] = ColumnDef[Double]("var_disc")
 
+    sealed trait GetVariableDiscountUpdateInventory extends RequestResponseProtocol.Message
     // order items: i_id, i_quantity, i_min_price, i_price, i_fixed_disc
-    case class Request(customerId: Int, cartTime: ZonedDateTime, orderItems: Relation) extends RequestResponseProtocol.Request
+    case class Request(customerId: Int, cartTime: ZonedDateTime, orderItems: Relation) extends RequestResponseProtocol.Request[GetVariableDiscountUpdateInventory]
     // result: amount, fixed_disc, var_disc
-    case class Success(result: Relation) extends RequestResponseProtocol.Success
-    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
+    case class Success(result: Relation) extends RequestResponseProtocol.Success[GetVariableDiscountUpdateInventory]
+    case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetVariableDiscountUpdateInventory]
 
   }
 


### PR DESCRIPTION
## Proposed Changes

- Change `RequestResponseProtocol` to be compatible with envisioned `MultiDactorFunctions`, specifically the `SequentialFunction`
- Add `Message` types to `Request`, `Response`, and the subtypes (`Success` and `Failure`)

Message definitions will change from:
```scala
object GetCustomerGroupId {
  case class Request() extends RequestResponseProtocol.Request
  case class Success(result: Relation) extends RequestResponseProtocol.Success
  case class Failure(e: Throwable) extends RequestResponseProtocol.Failure
}
```
to
```scala
object GetCustomerGroupId {
  sealed trait GetCustomerGroupId extends Message
  case class Request() extends RequestResponseProtocol.Request[GetCustomerGroupId]
  case class Success(result: Relation) extends RequestResponseProtocol.Response[GetCustomerGroupId]
  case class Failure(e: Throwable) extends RequestResponseProtocol.Failure[GetCustomerGroupId]
}
```

## Related

- **merge #105 first**
